### PR TITLE
:sparkles: Feat: 설정 파일 분리하여 Submodule 구성함

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "IoT-Secret"]
+	path = IoT-Secret
+	url = https://github.com/Monorama-IoT-Platform/IoT-Secret.git

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,18 @@ repositories {
     mavenCentral()
 }
 
+tasks.register('copyPrivate', Copy) {
+    copy {
+        from './IoT-Secret'
+        include "*.yml"
+        into 'src/main/resources'
+    }
+}
+
+tasks.named('processResources') {
+    dependsOn 'copyPrivate'
+}
+
 dependencies {
     /** Spring Boot starters **/
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'


### PR DESCRIPTION
## 🔗 관련 이슈
Resolves: [[feat] 민감 설정 정보 별도 private 레포지토리로 분리 #5](https://github.com/Monorama-IoT-Platform/IoT-Server/issues/5)

## 📝 개요
- 민감한 설정 파일을 분리하여 보안 강화를 위한 작업을 수행함

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [x] 빌드 / CI 관련 변경

## ✅ 상세 내용
- GitHub private 레포지토리 'IoT-Secret' 생성 및 연동
- `.gitmodules` 파일 추가 및 서브모듈 등록
- `IoT-Secret` 내 yml 파일을 Gradle 빌드시 자동 복사되도록 `copyPrivate` task 구성
- `processResources` task에 의존성 추가하여 자원 처리 시 복사 선행되도록 설정

## 테스트
- [x] Resources의 application 파일 삭제 후 DB 연동 테스트 완료

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 테스트가 통과되었습니다.
- [x] 문서가 반영되었습니다.
- [x] 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 코드/로그가 제거되었습니다.
