### PR TITLE
✨ Feat: 헬스데이터 회원가입 약관 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ tasks.named('processResources') {
 dependencies {
     /** Spring Boot starters **/
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    //implementation 'org.springframework.boot:spring-boot-starter-security'
+    //implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -58,7 +58,7 @@ dependencies {
 
     /** Development tools **/
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
+    //developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
     /** Testing dependencies **/
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ tasks.named('processResources') {
 dependencies {
     /** Spring Boot starters **/
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
-    //implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/monorama/iot_server/controller/HealthData/HealthTermsController.java
+++ b/src/main/java/com/monorama/iot_server/controller/HealthData/HealthTermsController.java
@@ -1,5 +1,6 @@
 package com.monorama.iot_server.controller.HealthData;
 
+import com.monorama.iot_server.domain.type.ServiceType;
 import com.monorama.iot_server.dto.ResponseDto;
 import com.monorama.iot_server.dto.response.terms.TermsListResponseDto;
 import com.monorama.iot_server.service.TermsService;
@@ -17,9 +18,7 @@ public class HealthTermsController {
 
     @GetMapping
     public ResponseDto<TermsListResponseDto> getTerms() {
-        TermsListResponseDto result = termsService.getHealthSignupTerms();
+        TermsListResponseDto result = termsService.getTermsByProjectType(ServiceType.HEALTH_DATA);
         return ResponseDto.ok(result);
     }
 }
-
-

--- a/src/main/java/com/monorama/iot_server/controller/HealthData/HealthTermsController.java
+++ b/src/main/java/com/monorama/iot_server/controller/HealthData/HealthTermsController.java
@@ -4,7 +4,6 @@ import com.monorama.iot_server.dto.ResponseDto;
 import com.monorama.iot_server.dto.response.terms.TermsListResponseDto;
 import com.monorama.iot_server.service.TermsService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,9 +16,9 @@ public class HealthTermsController {
     private final TermsService termsService;
 
     @GetMapping
-    public ResponseEntity<ResponseDto<TermsListResponseDto>> getTerms() {
+    public ResponseDto<TermsListResponseDto> getTerms() {
         TermsListResponseDto result = termsService.getHealthSignupTerms();
-        return ResponseEntity.ok(ResponseDto.ok(result));
+        return ResponseDto.ok(result);
     }
 }
 

--- a/src/main/java/com/monorama/iot_server/controller/HealthData/HealthTermsController.java
+++ b/src/main/java/com/monorama/iot_server/controller/HealthData/HealthTermsController.java
@@ -1,4 +1,4 @@
-package com.monorama.iot_server.controller;
+package com.monorama.iot_server.controller.HealthData;
 
 import com.monorama.iot_server.dto.ResponseDto;
 import com.monorama.iot_server.dto.response.terms.TermsListResponseDto;
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/health-data/terms")
 @RequiredArgsConstructor
-public class TermsController {
+public class HealthTermsController {
 
     private final TermsService termsService;
 

--- a/src/main/java/com/monorama/iot_server/controller/TermsController.java
+++ b/src/main/java/com/monorama/iot_server/controller/TermsController.java
@@ -1,0 +1,26 @@
+package com.monorama.iot_server.controller;
+
+import com.monorama.iot_server.dto.ResponseDto;
+import com.monorama.iot_server.dto.response.terms.TermsListResponseDto;
+import com.monorama.iot_server.service.TermsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/health-data/terms")
+@RequiredArgsConstructor
+public class TermsController {
+
+    private final TermsService termsService;
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<TermsListResponseDto>> getTerms() {
+        TermsListResponseDto result = termsService.getHealthSignupTerms();
+        return ResponseEntity.ok(ResponseDto.ok(result));
+    }
+}
+
+

--- a/src/main/java/com/monorama/iot_server/domain/Terms.java
+++ b/src/main/java/com/monorama/iot_server/domain/Terms.java
@@ -1,0 +1,33 @@
+package com.monorama.iot_server.domain;
+
+import com.monorama.iot_server.domain.type.TermsType;
+import com.monorama.iot_server.dto.response.terms.TermsResponseDto;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "terms_tb")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Terms {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "terms_type", nullable = false)
+    private TermsType type;
+
+    @Column(length = 20, nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public TermsResponseDto toDto() {
+        return TermsResponseDto.of(type.toString(), title, content);
+    }
+}

--- a/src/main/java/com/monorama/iot_server/domain/Terms.java
+++ b/src/main/java/com/monorama/iot_server/domain/Terms.java
@@ -1,5 +1,6 @@
 package com.monorama.iot_server.domain;
 
+import com.monorama.iot_server.domain.type.ServiceType;
 import com.monorama.iot_server.domain.type.TermsType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -19,6 +20,10 @@ public class Terms {
     @Enumerated(EnumType.STRING)
     @Column(name = "terms_type", nullable = false)
     private TermsType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "service_type", nullable = false)
+    private ServiceType serviceType;
 
     @Column(length = 20, nullable = false)
     private String title;

--- a/src/main/java/com/monorama/iot_server/domain/Terms.java
+++ b/src/main/java/com/monorama/iot_server/domain/Terms.java
@@ -1,7 +1,6 @@
 package com.monorama.iot_server.domain;
 
 import com.monorama.iot_server.domain.type.TermsType;
-import com.monorama.iot_server.dto.response.terms.TermsResponseDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -26,8 +25,4 @@ public class Terms {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
-
-    public TermsResponseDto toDto() {
-        return TermsResponseDto.of(type.toString(), title, content);
-    }
 }

--- a/src/main/java/com/monorama/iot_server/domain/type/ServiceType.java
+++ b/src/main/java/com/monorama/iot_server/domain/type/ServiceType.java
@@ -1,0 +1,15 @@
+package com.monorama.iot_server.domain.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ServiceType {
+    HEALTH_DATA("HEALTH_DATA"), AIR_QUALITY("AIR_QUALITY"), PM_WEB("PM_WEB");
+
+    private final String serviceType;
+
+    @Override
+    public String toString() {
+        return serviceType;
+    }
+}

--- a/src/main/java/com/monorama/iot_server/domain/type/TermsType.java
+++ b/src/main/java/com/monorama/iot_server/domain/type/TermsType.java
@@ -1,0 +1,16 @@
+package com.monorama.iot_server.domain.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum TermsType {
+    PRIVACY_POLICY("PRIVACY_POLICY"),
+    TERMS_OF_SERVICE("TERMS_OF_SERVICE");
+
+    private final String termsType;
+
+    @Override
+    public String toString() {
+        return termsType;
+    }
+}

--- a/src/main/java/com/monorama/iot_server/dto/response/terms/TermsListResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/terms/TermsListResponseDto.java
@@ -1,0 +1,11 @@
+package com.monorama.iot_server.dto.response.terms;
+
+import java.util.List;
+
+public record TermsListResponseDto(
+        List<TermsResponseDto> terms
+) {
+    public static TermsListResponseDto of(List<TermsResponseDto> terms) {
+        return new TermsListResponseDto(terms);
+    }
+}

--- a/src/main/java/com/monorama/iot_server/dto/response/terms/TermsResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/terms/TermsResponseDto.java
@@ -1,0 +1,11 @@
+package com.monorama.iot_server.dto.response.terms;
+
+public record TermsResponseDto(
+        String type,
+        String title,
+        String content
+) {
+    public static TermsResponseDto of(String type, String title, String content) {
+        return new TermsResponseDto(type, title, content);
+    }
+}

--- a/src/main/java/com/monorama/iot_server/dto/response/terms/TermsResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/terms/TermsResponseDto.java
@@ -1,11 +1,18 @@
 package com.monorama.iot_server.dto.response.terms;
 
+import com.monorama.iot_server.domain.Terms;
+
 public record TermsResponseDto(
         String type,
         String title,
         String content
 ) {
-    public static TermsResponseDto of(String type, String title, String content) {
-        return new TermsResponseDto(type, title, content);
+
+    public static TermsResponseDto fromEntity(Terms terms) {
+        return new TermsResponseDto(
+                terms.getType().toString(),
+                terms.getTitle(),
+                terms.getContent()
+        );
     }
 }

--- a/src/main/java/com/monorama/iot_server/repository/TermsRepository.java
+++ b/src/main/java/com/monorama/iot_server/repository/TermsRepository.java
@@ -1,0 +1,11 @@
+package com.monorama.iot_server.repository;
+
+import com.monorama.iot_server.domain.Terms;
+import com.monorama.iot_server.domain.type.TermsType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+    List<Terms> findByTypeIn(List<TermsType> types);
+}

--- a/src/main/java/com/monorama/iot_server/repository/TermsRepository.java
+++ b/src/main/java/com/monorama/iot_server/repository/TermsRepository.java
@@ -1,11 +1,12 @@
 package com.monorama.iot_server.repository;
 
 import com.monorama.iot_server.domain.Terms;
+import com.monorama.iot_server.domain.type.ServiceType;
 import com.monorama.iot_server.domain.type.TermsType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface TermsRepository extends JpaRepository<Terms, Long> {
-    List<Terms> findByTypeIn(List<TermsType> types);
+    List<Terms> findByTypeInAndServiceType(List<TermsType> types, ServiceType serviceType);
 }

--- a/src/main/java/com/monorama/iot_server/service/TermsService.java
+++ b/src/main/java/com/monorama/iot_server/service/TermsService.java
@@ -1,0 +1,33 @@
+package com.monorama.iot_server.service;
+
+import com.monorama.iot_server.domain.Terms;
+import com.monorama.iot_server.domain.type.TermsType;
+import com.monorama.iot_server.dto.response.terms.TermsListResponseDto;
+import com.monorama.iot_server.dto.response.terms.TermsResponseDto;
+import com.monorama.iot_server.repository.TermsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TermsService {
+
+    private final TermsRepository termsRepository;
+
+    public TermsListResponseDto getHealthSignupTerms() {
+        List<Terms> termsList = termsRepository.findByTypeIn(List.of(
+                TermsType.PRIVACY_POLICY,
+                TermsType.TERMS_OF_SERVICE
+        ));
+
+        List<TermsResponseDto> dtoList = termsList.stream()
+                .map(Terms::toDto)
+                .collect(Collectors.toList());
+
+        return TermsListResponseDto.of(dtoList);
+    }
+}
+

--- a/src/main/java/com/monorama/iot_server/service/TermsService.java
+++ b/src/main/java/com/monorama/iot_server/service/TermsService.java
@@ -1,6 +1,7 @@
 package com.monorama.iot_server.service;
 
 import com.monorama.iot_server.domain.Terms;
+import com.monorama.iot_server.domain.type.ServiceType;
 import com.monorama.iot_server.domain.type.TermsType;
 import com.monorama.iot_server.dto.response.terms.TermsListResponseDto;
 import com.monorama.iot_server.dto.response.terms.TermsResponseDto;
@@ -17,18 +18,18 @@ public class TermsService {
 
     private final TermsRepository termsRepository;
 
-    public TermsListResponseDto getHealthSignupTerms() {
-        List<Terms> termsList = termsRepository.findByTypeIn(List.of(
-                TermsType.PRIVACY_POLICY,
-                TermsType.TERMS_OF_SERVICE
-        ));
+    public TermsListResponseDto getTermsByProjectType(ServiceType serviceType) {
+        List<Terms> termsList = termsRepository.findByTypeInAndServiceType(
+                List.of(TermsType.PRIVACY_POLICY, TermsType.TERMS_OF_SERVICE),
+                serviceType
+        );
 
         List<TermsResponseDto> dtoList = termsList.stream()
                 .map(TermsResponseDto::fromEntity)
                 .collect(Collectors.toList());
 
-
         return TermsListResponseDto.of(dtoList);
     }
 }
+
 

--- a/src/main/java/com/monorama/iot_server/service/TermsService.java
+++ b/src/main/java/com/monorama/iot_server/service/TermsService.java
@@ -24,8 +24,9 @@ public class TermsService {
         ));
 
         List<TermsResponseDto> dtoList = termsList.stream()
-                .map(Terms::toDto)
+                .map(TermsResponseDto::fromEntity)
                 .collect(Collectors.toList());
+
 
         return TermsListResponseDto.of(dtoList);
     }


### PR DESCRIPTION
## 🔗 관련 이슈
Resolves: #8

## 📝 개요
- 헬스데이터 앱 회원가입 시 약관 조회 기능을 구현함
- 약관 유형을 관리할 수 있는 Terms 엔티티 및 TermsType enum을 정의함

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [x] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- Terms 엔티티 및 TermsType enum 생성하여 DB 테이블 매핑 구조 정의함
- 약관 조회 API `GET /api/v1/health-data/terms` 구현함
  - HealthTermsController → TermsService → TermsRepository 구조
- 패키지 구조 `controller.health`로 이동하여 컨텍스트 기반으로 정리함
- 응답 포맷은 ResponseDto(record 기반)로 표준화함
- 약관 타입은 ENUM(PRIVACY_POLICY, TERMS_OF_SERVICE)로 관리

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 테스트 데이터로 API 정상 응답을 확인했습니다.
- [x] 문서 또는 PR 설명이 반영되었습니다.
- [x] 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 코드/로그가 제거되었습니다.

