### PR TITLE
:sparkles: Feat: 구글 소셜 로그인 기능 추가

### DIFF
--- a/src/main/java/com/monorama/iot_server/config/SecurityConfig.java
+++ b/src/main/java/com/monorama/iot_server/config/SecurityConfig.java
@@ -1,0 +1,88 @@
+package com.monorama.iot_server.config;
+
+import com.monorama.iot_server.constant.Constant;
+import com.monorama.iot_server.security.JwtAuthEntryPoint;
+import com.monorama.iot_server.security.JwtAuthenticationProvider;
+import com.monorama.iot_server.security.filter.JwtAuthenticationFilter;
+import com.monorama.iot_server.security.filter.JwtExceptionFilter;
+import com.monorama.iot_server.security.handler.*;
+import com.monorama.iot_server.security.service.CustomOAuth2UserService;
+import com.monorama.iot_server.security.service.CustomUserDetailService;
+import com.monorama.iot_server.type.ERole;
+import com.monorama.iot_server.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final DefaultSuccessHandler defaultSuccessHandler;
+    private final DefaultFaiureHandler defaultFailureHandler;
+
+    private final CustomUserDetailService customUserDetailService;
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    private final JwtUtil jwtUtil;
+
+    private final JwtAuthEntryPoint jwtAuthEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    private final CustomLogOutProcessHandler customLogOutProcessHandler;
+    private final CustomLogOutResultHandler customLogOutResultHandler;
+
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+
+    @Bean
+    protected SecurityFilterChain securityFilterChain(final HttpSecurity httpSecurity) throws Exception {
+
+
+        return httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement((sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(requestMatcherRegistry -> requestMatcherRegistry
+                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/projects/**").hasAnyRole((ERole.PM.toString()),ERole.BOTH_USER.toString(), ERole.AIR_QUALITY_USER.toString(), ERole.HEALTH_DATA_USER.toString())
+                        .requestMatchers("/health-data/**").hasAnyRole((ERole.BOTH_USER.toString()),ERole.HEALTH_DATA_USER.toString())
+                        .requestMatchers("/air-quality-data/**").hasAnyRole((ERole.BOTH_USER.toString()), ERole.AIR_QUALITY_USER.toString())
+                        .anyRequest().authenticated())
+
+                .oauth2Login(
+                        configurer ->
+                                configurer
+                                        .successHandler(oAuth2LoginSuccessHandler)
+                                        .failureHandler(oAuth2LoginFailureHandler)
+                                        .userInfoEndpoint(userInfoEndpoint ->
+                                                userInfoEndpoint.userService(customOAuth2UserService))
+                )
+                .logout(configurer ->
+                        configurer
+                                .logoutUrl("/auth/logout")
+                                .addLogoutHandler(customLogOutProcessHandler)
+                                .logoutSuccessHandler(customLogOutResultHandler)
+                                .deleteCookies(Constant.AUTHORIZATION,Constant.REAUTHORIZATION)
+                )
+                .exceptionHandling(configurer ->
+                        configurer
+                                .authenticationEntryPoint(jwtAuthEntryPoint)
+                                .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
+
+
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, new JwtAuthenticationProvider(customUserDetailService)), LogoutFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class)
+                .getOrBuild();
+    }
+}

--- a/src/main/java/com/monorama/iot_server/constant/Constant.java
+++ b/src/main/java/com/monorama/iot_server/constant/Constant.java
@@ -19,6 +19,7 @@ public class Constant {
             "/oauth2/authorization/google",
             "/login/oauth2/code/naver",
             "/oauth2/authorization/naver",
-            "/auth/refresh"
+            "/auth/refresh",
+            "/favicon.ico"
     );
 }

--- a/src/main/java/com/monorama/iot_server/controller/AuthController.java
+++ b/src/main/java/com/monorama/iot_server/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.monorama.iot_server.controller;
+
+import com.monorama.iot_server.annotation.UserId;
+import com.monorama.iot_server.dto.ResponseDto;
+import com.monorama.iot_server.dto.request.PMRegisterDto;
+import com.monorama.iot_server.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService userService;
+
+    //소셜 회원가입
+    @PostMapping("/register/PM")
+    public ResponseDto<?> registerPM(@UserId Long userId, @RequestBody @Valid PMRegisterDto registerDto) {
+        return ResponseDto.created(userService.registerPM(userId, registerDto));
+    }
+
+}

--- a/src/main/java/com/monorama/iot_server/domain/User.java
+++ b/src/main/java/com/monorama/iot_server/domain/User.java
@@ -1,7 +1,8 @@
 package com.monorama.iot_server.domain;
 
 import com.monorama.iot_server.domain.embedded.PersonalInfoItem;
-import com.monorama.iot_server.domain.type.*;
+import com.monorama.iot_server.type.EProvider;
+import com.monorama.iot_server.type.ERole;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,9 +18,10 @@ import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.*;
 
 
-@Entity(name = "user_tb")
+@Entity
 @NoArgsConstructor
 @Getter
+@Table(name = "user_tb")
 public class User {
 
     @Id
@@ -30,16 +32,16 @@ public class User {
     @Embedded
     private PersonalInfoItem personalInfo;
 
-    @Enumerated(STRING)
+    @Enumerated(EnumType.STRING)
     @Column(name = "role")
-    private Role role;
+    private ERole role;
 
     @Column(name = "social_id")
     private String socialId;
 
-    @Enumerated(STRING)
+    @Enumerated(EnumType.STRING)
     @Column(name = "provider")
-    private LoginProvider provider;
+    private EProvider provider;
 
     @Column(name = "refresh_token")
     private String refreshToken;
@@ -71,11 +73,18 @@ public class User {
     private UserDataPermission userDataPermission;
 
     @Builder
-    public User(Role role, String socialId, LoginProvider provider, Boolean isLogin) {
+    public User(ERole role, String socialId, EProvider provider) {
         this.role = role;
         this.socialId = socialId;
         this.provider = provider;
-        this.isLogin = isLogin;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void register(PersonalInfoItem personalInfo) {
+        this.personalInfo = personalInfo;
     }
 
     private void setUserDataPermission(UserDataPermission userDataPermission) {

--- a/src/main/java/com/monorama/iot_server/domain/embedded/PersonalInfoItem.java
+++ b/src/main/java/com/monorama/iot_server/domain/embedded/PersonalInfoItem.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,7 +16,8 @@ import java.util.Date;
 
 @Embeddable
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@AllArgsConstructor
 public class PersonalInfoItem {
 
     @Column(name = "name")

--- a/src/main/java/com/monorama/iot_server/dto/request/PMRegisterDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/request/PMRegisterDto.java
@@ -1,0 +1,34 @@
+package com.monorama.iot_server.dto.request;
+
+import com.monorama.iot_server.domain.embedded.PersonalInfoItem;
+import com.monorama.iot_server.domain.type.BloodType;
+import com.monorama.iot_server.domain.type.Gender;
+import com.monorama.iot_server.domain.type.NationalCode;
+
+import java.util.Date;
+
+public record PMRegisterDto(
+        String name,
+        String email,
+        Gender gender,
+        NationalCode nationalCode,
+        String phoneNumber,
+        Date dateOfBirth,
+        BloodType bloodType,
+        Double height,
+        Double weight
+) {
+    public PersonalInfoItem toEntity() {
+        return new PersonalInfoItem(
+                name,
+                email,
+                gender,
+                nationalCode,
+                phoneNumber,
+                dateOfBirth,
+                bloodType,
+                height,
+                weight
+        );
+    }
+}

--- a/src/main/java/com/monorama/iot_server/repository/UserRepository.java
+++ b/src/main/java/com/monorama/iot_server/repository/UserRepository.java
@@ -1,0 +1,55 @@
+package com.monorama.iot_server.repository;
+
+import com.monorama.iot_server.domain.User;
+import com.monorama.iot_server.type.EProvider;
+import com.monorama.iot_server.type.ERole;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<UserSecurityForm> findByIdAndIsLoginAndRefreshTokenIsNotNull(Long id, boolean b);
+
+    Optional<UserSecurityForm> findByRefreshToken(String refreshToken);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE User u SET u.refreshToken = :refreshToken, u.isLogin = :status WHERE u.id = :id")
+    void updateRefreshTokenAndLoginStatus(Long id, String refreshToken, Boolean status);
+
+    Optional<UserSecurityForm> findBySocialId(String socialId);
+
+    @Query("SELECT u.id as id, u.role as role " +
+            "FROM User u WHERE u.socialId = :socialId AND u.provider = :provider")
+    Optional<UserSecurityForm> findBySocialIdAndEProvider(String socialId, EProvider provider);
+
+
+    interface UserSecurityForm {
+
+        static UserSecurityForm invoke(User user) {
+
+
+            return new UserSecurityForm() {
+                @Override
+                public Long getId() {
+                    return user.getId();
+                }
+
+
+                @Override
+                public ERole getRole() {
+                    return user.getRole();
+                }
+            };
+        }
+
+        Long getId();
+
+        ERole getRole();
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/AbstractAuthenticationFailure.java
+++ b/src/main/java/com/monorama/iot_server/security/AbstractAuthenticationFailure.java
@@ -1,0 +1,25 @@
+package com.monorama.iot_server.security;
+import com.monorama.iot_server.dto.ExceptionDto;
+import com.monorama.iot_server.exception.ErrorCode;
+import io.jsonwebtoken.io.IOException;
+import jakarta.servlet.http.HttpServletResponse;
+import net.minidev.json.JSONValue;
+
+import java.util.HashMap;
+import java.util.Map;
+public abstract class AbstractAuthenticationFailure {
+    protected void setErrorResponse(
+            HttpServletResponse response,
+            ErrorCode errorCode) throws IOException, java.io.IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getHttpStatus().value());
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("success", false);
+        result.put("data", null);
+        result.put("error", new ExceptionDto(errorCode, errorCode.getMessage()));
+
+        response.getWriter().write(JSONValue.toJSONString(result));
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/JwtAuthEntryPoint.java
+++ b/src/main/java/com/monorama/iot_server/security/JwtAuthEntryPoint.java
@@ -1,0 +1,23 @@
+package com.monorama.iot_server.security;
+
+import com.monorama.iot_server.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthEntryPoint extends AbstractAuthenticationFailure implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(final HttpServletRequest request,
+                         final HttpServletResponse response,
+                         final AuthenticationException authException) throws IOException {
+        setErrorResponse(response,ErrorCode.INVALID_TOKEN_ERROR);
+    }
+
+
+}

--- a/src/main/java/com/monorama/iot_server/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/monorama/iot_server/security/JwtAuthenticationProvider.java
@@ -1,0 +1,43 @@
+package com.monorama.iot_server.security;
+
+import com.monorama.iot_server.security.info.JwtUserInfo;
+import com.monorama.iot_server.security.info.UserPrincipal;
+import com.monorama.iot_server.security.service.CustomUserDetailService;
+import com.monorama.iot_server.type.ERole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+    private final CustomUserDetailService customUserDetailService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+
+        UserPrincipal userPrincipal = null;
+        if (authentication instanceof JwtAuthenticationToken) {
+            JwtUserInfo jwtUserInfo = new JwtUserInfo((Long) authentication.getPrincipal(), (ERole) authentication.getCredentials());
+            userPrincipal = (UserPrincipal) customUserDetailService.loadUserByUserId(jwtUserInfo.id());
+
+            if (userPrincipal.getRole() != jwtUserInfo.role()) {
+                throw new AuthenticationException("Invalid Role") {
+                };
+            }
+        }
+
+        return new UsernamePasswordAuthenticationToken(userPrincipal, null, userPrincipal.getAuthorities());
+    }
+
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(JwtAuthenticationToken.class)
+                || authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/JwtAuthenticationToken.java
+++ b/src/main/java/com/monorama/iot_server/security/JwtAuthenticationToken.java
@@ -1,0 +1,38 @@
+package com.monorama.iot_server.security;
+
+import com.monorama.iot_server.type.ERole;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+    private Long userId;
+    private ERole role;
+
+    /**
+     * Creates a token with the supplied array of authorities.
+     *
+     * @param authorities the collection of <tt>GrantedAuthority</tt>s for the principal
+     *                    represented by this authentication object.
+     */
+    public JwtAuthenticationToken(Collection<? extends GrantedAuthority> authorities, Long userId, ERole role) {
+        super(authorities);
+        this.userId = userId;
+        this.role = role;
+    }
+
+    public JwtAuthenticationToken(Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.role;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.userId;
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/monorama/iot_server/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.monorama.iot_server.security.filter;
+
+import com.monorama.iot_server.constant.Constant;
+import com.monorama.iot_server.exception.CommonException;
+import com.monorama.iot_server.exception.ErrorCode;
+import com.monorama.iot_server.security.JwtAuthenticationProvider;
+import com.monorama.iot_server.security.JwtAuthenticationToken;
+import com.monorama.iot_server.security.info.JwtUserInfo;
+import com.monorama.iot_server.type.ERole;
+import com.monorama.iot_server.util.HeaderUtil;
+import com.monorama.iot_server.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@AllArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws JwtException, ServletException, IOException {
+
+        final String token = HeaderUtil.refineHeader(request,Constant.AUTHORIZATION_HEADER,Constant.BEARER_PREFIX)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN_ERROR));
+
+        final Claims claims = jwtUtil.validateToken(token);
+        JwtUserInfo userInfo = new JwtUserInfo(
+                Long.valueOf(claims.get(Constant.USER_ID_CLAIM_NAME,String.class)),
+                ERole.valueOf(claims.get(Constant.USER_ROLE_CLAIM_NAME, String.class))
+        );
+
+        JwtAuthenticationToken beforeAuthentication = new JwtAuthenticationToken(
+                null,
+                userInfo.id(),
+                userInfo.role()
+        );
+        UsernamePasswordAuthenticationToken afterAuthentication =
+                (UsernamePasswordAuthenticationToken)  jwtAuthenticationProvider.authenticate(beforeAuthentication);
+
+        afterAuthentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+        final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(afterAuthentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        log.info(request.getRequestURI());
+        log.info(String.valueOf(Constant.NO_NEED_AUTH_URLS.contains(request.getRequestURI())));
+        return Constant.NO_NEED_AUTH_URLS.contains(request.getRequestURI())
+                || request.getRequestURI().startsWith("/guest");
+    }
+
+}

--- a/src/main/java/com/monorama/iot_server/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/monorama/iot_server/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,77 @@
+package com.monorama.iot_server.security.filter;
+
+import com.monorama.iot_server.constant.Constant;
+import com.monorama.iot_server.exception.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (SecurityException e) {
+            e.printStackTrace();
+            log.error("FilterException throw SecurityException Exception : {}", e.getMessage());
+            request.setAttribute("exception", ErrorCode.ACCESS_DENIED_ERROR);
+            filterChain.doFilter(request, response);
+        } catch (MalformedJwtException e) {
+            e.printStackTrace();
+            log.error("FilterException throw MalformedJwtException Exception : {}", e.getMessage());
+            request.setAttribute("exception", ErrorCode.TOKEN_MALFORMED_ERROR);
+
+            filterChain.doFilter(request, response);
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            log.error("FilterException throw IllegalArgumentException Exception : {}", e.getMessage());
+            request.setAttribute("exception", ErrorCode.TOKEN_TYPE_ERROR);
+
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            e.printStackTrace();
+            log.error("FilterException throw ExpiredJwtException Exception : {}", e.getMessage());
+            request.setAttribute("exception", ErrorCode.EXPIRED_TOKEN_ERROR);
+
+            filterChain.doFilter(request, response);
+        } catch (UnsupportedJwtException e) {
+            e.printStackTrace();
+            log.error("FilterException throw UnsupportedJwtException Exception : {}", e.getMessage());
+            request.setAttribute("exception", ErrorCode.TOKEN_UNSUPPORTED_ERROR);
+
+            filterChain.doFilter(request, response);
+        } catch (JwtException e) {
+            e.printStackTrace();
+            log.error("FilterException throw JwtException Exception : {}", e.getMessage());
+            request.setAttribute("exception", ErrorCode.TOKEN_UNKNOWN_ERROR);
+
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            e.printStackTrace();
+            log.error("FilterException throw Exception Exception : {}", e.getMessage());
+            request.setAttribute("exception", ErrorCode.NOT_FOUND_USER);
+
+            filterChain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return Constant.NO_NEED_AUTH_URLS.contains(request.getRequestURI())
+                || request.getRequestURI().startsWith("/guest");
+    }
+}
+

--- a/src/main/java/com/monorama/iot_server/security/handler/CustomLogOutProcessHandler.java
+++ b/src/main/java/com/monorama/iot_server/security/handler/CustomLogOutProcessHandler.java
@@ -1,0 +1,29 @@
+package com.monorama.iot_server.security.handler;
+
+import com.monorama.iot_server.repository.UserRepository;
+import com.monorama.iot_server.security.info.UserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomLogOutProcessHandler implements LogoutHandler {
+    private final UserRepository userRepository;
+    @Override
+    @Transactional
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        if(authentication == null){
+            return;
+        }
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+        userRepository.updateRefreshTokenAndLoginStatus(userPrincipal.getId(),null,Boolean.FALSE);
+
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/handler/CustomLogOutResultHandler.java
+++ b/src/main/java/com/monorama/iot_server/security/handler/CustomLogOutResultHandler.java
@@ -1,0 +1,32 @@
+package com.monorama.iot_server.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import net.minidev.json.JSONValue;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomLogOutResultHandler implements LogoutSuccessHandler  {
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        response.setContentType("application/json;charset=UTF-8");
+        setSuccessResponse(response);
+    }
+    private void setSuccessResponse(HttpServletResponse response) throws IOException {
+        Map<String, Object> result = new HashMap<>();
+        result.put("success", Boolean.TRUE);
+        result.put("data","logout success");
+        result.put("error", null);
+        response.getWriter().write(JSONValue.toJSONString(result));
+    }
+//    private void setFailureResponse(HttpServletResponse response) throws IOException {
+//        setErrorResponse(response,ErrorCode.FAILURE_LOGIN);
+//    }
+}

--- a/src/main/java/com/monorama/iot_server/security/handler/DefaultFaiureHandler.java
+++ b/src/main/java/com/monorama/iot_server/security/handler/DefaultFaiureHandler.java
@@ -1,0 +1,22 @@
+package com.monorama.iot_server.security.handler;
+
+import com.monorama.iot_server.exception.ErrorCode;
+import com.monorama.iot_server.security.AbstractAuthenticationFailure;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class DefaultFaiureHandler extends AbstractAuthenticationFailure implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception) throws IOException {
+        setErrorResponse(response, ErrorCode.FAILURE_LOGIN);
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/handler/DefaultSuccessHandler.java
+++ b/src/main/java/com/monorama/iot_server/security/handler/DefaultSuccessHandler.java
@@ -1,0 +1,72 @@
+package com.monorama.iot_server.security.handler;
+
+import com.monorama.iot_server.constant.Constant;
+import com.monorama.iot_server.dto.JwtTokenDto;
+import com.monorama.iot_server.repository.UserRepository;
+import com.monorama.iot_server.security.info.UserPrincipal;
+import com.monorama.iot_server.util.CookieUtil;
+import com.monorama.iot_server.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONValue;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DefaultSuccessHandler implements AuthenticationSuccessHandler {
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication) throws IOException {
+        // 유저의 인증된 정보를 들고오고
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+        JwtTokenDto tokenDto = jwtUtil.generateTokens(userPrincipal.getId(), userPrincipal.getRole());
+        userRepository.updateRefreshTokenAndLoginStatus(userPrincipal.getId(), tokenDto.getRefreshToken(), Boolean.TRUE);
+        // WEB , APP 구분
+        String userAgent = request.getHeader("User-Agent");
+
+        if (userAgent == null) {
+            setSuccessAppResponse(response, tokenDto);
+        } else {
+            setSuccessWebResponse(response, tokenDto);
+        }
+    }
+
+    private void setSuccessAppResponse(HttpServletResponse response, JwtTokenDto tokenDto) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.OK.value());
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("success", true);
+        result.put("data", Map.of(
+                Constant.AUTHORIZATION, tokenDto.getAccessToken(),
+                        Constant.REAUTHORIZATION, tokenDto.getRefreshToken()
+                )
+        );
+        result.put("error", null);
+
+        response.getWriter().write(JSONValue.toJSONString(result));
+    }
+
+    private void setSuccessWebResponse(HttpServletResponse response, JwtTokenDto tokenDto) throws IOException {
+        CookieUtil.addCookie(response, Constant.AUTHORIZATION, tokenDto.getAccessToken());
+        CookieUtil.addSecureCookie(response, Constant.REAUTHORIZATION, tokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
+
+        response.sendRedirect("http://localhost:5173");
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/monorama/iot_server/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,23 @@
+package com.monorama.iot_server.security.handler;
+
+import com.monorama.iot_server.exception.ErrorCode;
+import com.monorama.iot_server.security.AbstractAuthenticationFailure;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler extends AbstractAuthenticationFailure implements AccessDeniedHandler {
+
+    @Override
+    public void handle(final HttpServletRequest request,
+                       final HttpServletResponse response,
+                       final AccessDeniedException accessDeniedException) throws IOException {
+        setErrorResponse(response,ErrorCode.ACCESS_DENIED_ERROR);
+    }
+
+}

--- a/src/main/java/com/monorama/iot_server/security/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/monorama/iot_server/security/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,22 @@
+package com.monorama.iot_server.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("Social Login Fail"+exception.getMessage());
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/monorama/iot_server/security/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,55 @@
+package com.monorama.iot_server.security.handler;
+
+import com.monorama.iot_server.constant.Constant;
+import com.monorama.iot_server.dto.JwtTokenDto;
+import com.monorama.iot_server.repository.UserRepository;
+import com.monorama.iot_server.security.info.UserPrincipal;
+import com.monorama.iot_server.type.ERole;
+import com.monorama.iot_server.util.CookieUtil;
+import com.monorama.iot_server.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException, ServletException {
+        AuthenticationSuccessHandler.super.onAuthenticationSuccess(request, response, chain, authentication);
+    }
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+
+        JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(userPrincipal.getId(), userPrincipal.getRole());
+        userRepository.updateRefreshTokenAndLoginStatus(userPrincipal.getId(), jwtTokenDto.getRefreshToken(),Boolean.TRUE);
+
+        CookieUtil.addCookie(response, Constant.AUTHORIZATION, jwtTokenDto.getAccessToken());
+        CookieUtil.addSecureCookie(response, Constant.REAUTHORIZATION, jwtTokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
+
+        // Guest 즉, 소셜로그인으로 방금 가입한 유저는 따로 로직 분류
+
+        if (userPrincipal.getRole().equals(ERole.GUEST)) {
+            response.sendRedirect( "http://localhost:5173/auth/register/social" + jwtTokenDto.getAccessToken());
+        } else {
+            response.sendRedirect("http://localhost:5173");
+        }
+
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/info/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/monorama/iot_server/security/info/GoogleOAuth2UserInfo.java
@@ -1,0 +1,14 @@
+package com.monorama.iot_server.security.info;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return attributes.get("sub").toString();
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/info/JwtUserInfo.java
+++ b/src/main/java/com/monorama/iot_server/security/info/JwtUserInfo.java
@@ -1,0 +1,7 @@
+package com.monorama.iot_server.security.info;
+
+import com.monorama.iot_server.type.ERole;
+
+public record JwtUserInfo(Long id,ERole role) {
+
+}

--- a/src/main/java/com/monorama/iot_server/security/info/OAuth2UserInfo.java
+++ b/src/main/java/com/monorama/iot_server/security/info/OAuth2UserInfo.java
@@ -1,0 +1,16 @@
+package com.monorama.iot_server.security.info;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();
+}

--- a/src/main/java/com/monorama/iot_server/security/info/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/monorama/iot_server/security/info/OAuth2UserInfoFactory.java
@@ -1,0 +1,14 @@
+package com.monorama.iot_server.security.info;
+
+import com.monorama.iot_server.type.EProvider;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo getOAuth2UserInfo(EProvider provider, Map<String, Object> attributes) {
+        return switch (provider) {
+            case GOOGLE -> new GoogleOAuth2UserInfo(attributes);
+            default -> throw new IllegalArgumentException("Invalid Provider Type.");
+        };
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/info/UserPrincipal.java
+++ b/src/main/java/com/monorama/iot_server/security/info/UserPrincipal.java
@@ -1,0 +1,87 @@
+package com.monorama.iot_server.security.info;
+
+import com.monorama.iot_server.repository.UserRepository;
+import com.monorama.iot_server.type.ERole;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Builder
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserPrincipal implements UserDetails, OAuth2User {
+    @Getter private final Long id;      // 유저 정보 식별
+    @Getter private final ERole role;   // 유저와 JWT 권환 확인
+    private final String password;      // 유저의 비밀번호
+    private final Collection<? extends GrantedAuthority> authorities;   // 인가에서 사용할 권한 넣을 곳
+    private final Map<String, Object> attributes;   // OAuth2User 에서 사용할 정보 넣을 곳
+
+    public static UserPrincipal create(UserRepository.UserSecurityForm form) {
+        return UserPrincipal.builder()
+                .id(form.getId())
+                .role(form.getRole())
+                .attributes(Collections.emptyMap())
+                .authorities(Collections.singleton(new SimpleGrantedAuthority(form.getRole().toSecurityString()))).build();
+    }
+
+    public static UserPrincipal create(UserRepository.UserSecurityForm form, Map<String, Object> attributes) {
+        return UserPrincipal.builder()
+                .id(form.getId())
+                .role(form.getRole())
+                .attributes(attributes)
+                .authorities(Collections.singleton(new SimpleGrantedAuthority(form.getRole().toSecurityString()))).build();
+    }
+
+    @Override
+    public String getName() {
+        return id.toString();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return id.toString();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/monorama/iot_server/security/service/CustomOAuth2UserService.java
@@ -1,0 +1,55 @@
+package com.monorama.iot_server.security.service;
+
+import com.monorama.iot_server.domain.User;
+import com.monorama.iot_server.repository.UserRepository;
+import com.monorama.iot_server.security.info.OAuth2UserInfo;
+import com.monorama.iot_server.security.info.OAuth2UserInfoFactory;
+import com.monorama.iot_server.security.info.UserPrincipal;
+import com.monorama.iot_server.type.EProvider;
+import com.monorama.iot_server.type.EProviderFactory;
+import com.monorama.iot_server.type.ERole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+         try {
+             return process(userRequest, super.loadUser(userRequest));
+        }catch (Exception ex){
+             ex.printStackTrace();
+             throw ex;
+         }
+    }
+
+    public OAuth2User process(OAuth2UserRequest userRequest, OAuth2User oAuth2User){
+        EProvider provider = EProviderFactory.of(userRequest.getClientRegistration().getRegistrationId().toUpperCase(Locale.ROOT));
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(provider,oAuth2User.getAttributes());
+
+        UserRepository.UserSecurityForm userSecurityForm = userRepository.findBySocialIdAndEProvider(userInfo.getId(),provider)
+                .orElseGet(()->
+                {
+                    User user = userRepository.save(
+                            User.builder()
+                                    .role(ERole.GUEST)
+                                    .socialId(userInfo.getId())
+                                    .provider(provider)
+                                    .build()
+                    );
+                    return UserRepository.UserSecurityForm.invoke(user);
+                });
+
+        return UserPrincipal.create(userSecurityForm,oAuth2User.getAttributes());
+    }
+}

--- a/src/main/java/com/monorama/iot_server/security/service/CustomUserDetailService.java
+++ b/src/main/java/com/monorama/iot_server/security/service/CustomUserDetailService.java
@@ -1,0 +1,39 @@
+package com.monorama.iot_server.security.service;
+
+import com.monorama.iot_server.exception.CommonException;
+import com.monorama.iot_server.exception.ErrorCode;
+import com.monorama.iot_server.repository.UserRepository;
+import com.monorama.iot_server.security.info.UserPrincipal;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Getter
+@Slf4j
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        final UserRepository.UserSecurityForm user = userRepository.findBySocialId(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Not Found Username"));
+
+        return UserPrincipal.create(user);
+    }
+
+
+    public UserDetails loadUserByUserId(Long userId) throws CommonException {
+        final UserRepository.UserSecurityForm user = userRepository.findByIdAndIsLoginAndRefreshTokenIsNotNull(userId,true)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
+
+        return UserPrincipal.create(user);
+    }
+}
+

--- a/src/main/java/com/monorama/iot_server/service/AuthService.java
+++ b/src/main/java/com/monorama/iot_server/service/AuthService.java
@@ -1,0 +1,33 @@
+package com.monorama.iot_server.service;
+
+import com.monorama.iot_server.constant.Constant;
+import com.monorama.iot_server.domain.User;
+import com.monorama.iot_server.dto.JwtTokenDto;
+import com.monorama.iot_server.dto.request.PMRegisterDto;
+import com.monorama.iot_server.exception.CommonException;
+import com.monorama.iot_server.exception.ErrorCode;
+import com.monorama.iot_server.repository.UserRepository;
+import com.monorama.iot_server.util.JwtUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public JwtTokenDto registerPM(Long userId, PMRegisterDto registerDto) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CommonException(ErrorCode.NOT_FOUND_USER));
+        user.register(registerDto.toEntity());
+
+        final JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(user.getId(), user.getRole());
+        user.setRefreshToken(jwtTokenDto.getRefreshToken());
+
+        return jwtTokenDto;
+    }
+
+}

--- a/src/main/java/com/monorama/iot_server/type/EProvider.java
+++ b/src/main/java/com/monorama/iot_server/type/EProvider.java
@@ -1,9 +1,6 @@
 package com.monorama.iot_server.type;
 
 public enum EProvider {
-    KAKAO,
     GOOGLE,
-    NAVER,
-    GITHUB,
     DEFAULT
 }

--- a/src/main/java/com/monorama/iot_server/type/EProviderFactory.java
+++ b/src/main/java/com/monorama/iot_server/type/EProviderFactory.java
@@ -1,14 +1,9 @@
 package com.monorama.iot_server.type;
 
-import static com.monorama.iot_server.type.EProvider.KAKAO;
-
 public class EProviderFactory {
     public static EProvider of(String provider) {
         return switch (provider) {
-            case "KAKAO" -> KAKAO;
             case "GOOGLE" -> EProvider.GOOGLE;
-            case "NAVER" -> EProvider.NAVER;
-            case "GITHUB" -> EProvider.GITHUB;
             default -> throw new IllegalArgumentException("Invalid Provider Type.");
         };
     }

--- a/src/main/java/com/monorama/iot_server/type/ERole.java
+++ b/src/main/java/com/monorama/iot_server/type/ERole.java
@@ -4,7 +4,10 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ERole {
-    USER("USER", "ROLE_USER"),
+    PM("PM", "ROLE_PM"),
+    HEALTH_DATA_USER("HEALTH_DATA_USER", "ROLE_HEALTH_DATA_USER"),
+    AIR_QUALITY_USER("AIR_QUALITY_USER", "ROLE_AIR_QUALITY_USER"),
+    BOTH_USER("BOTH_USER", "ROLE_BOTH_USER"),
     ADMIN("ADMIN", "ROLE_ADMIN"),
     GUEST("GUEST", "ROLE_GUEST");
 

--- a/src/main/java/com/monorama/iot_server/util/JwtUtil.java
+++ b/src/main/java/com/monorama/iot_server/util/JwtUtil.java
@@ -1,0 +1,73 @@
+package com.monorama.iot_server.util;
+
+import com.monorama.iot_server.constant.Constant;
+import com.monorama.iot_server.dto.JwtTokenDto;
+import com.monorama.iot_server.repository.UserRepository;
+import com.monorama.iot_server.type.ERole;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil implements InitializingBean {
+    private static final Integer ACCESS_EXPIRED_MS = 2 * 60 * 60 * 1000;
+    private static final Integer REFRESH_EXPIRED_MS = 7 * 24 * 60 * 60 * 1000;
+
+
+    private final UserRepository userRepository;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+    private Key key;
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public JwtTokenDto generateTokens(Long id, ERole eRole) {
+        return new JwtTokenDto(generateAccessToken(id, eRole, ACCESS_EXPIRED_MS),
+                generateToken(null, REFRESH_EXPIRED_MS));
+    }
+
+    public Claims validateToken(final String token) throws JwtException {
+        final JwtParser jwtParser = Jwts.parserBuilder().setSigningKey(key).build();
+        return jwtParser.parseClaimsJws(token).getBody();
+    }
+
+    public String generateToken(Claims claims, final Integer expirationPeriod) {
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expirationPeriod))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String generateAccessToken(final Long id, final ERole role, final Integer expirationPeriod) {
+        final Claims claims = Jwts.claims();
+        claims.put(Constant.USER_ID_CLAIM_NAME, id.toString());
+        claims.put(Constant.USER_ROLE_CLAIM_NAME, role.toString());
+
+        return generateToken(claims, expirationPeriod);
+    }
+
+    public int getAccessTokenExpriration() {
+        return ACCESS_EXPIRED_MS;
+    }
+
+    public int getWebRefreshTokenExpirationSecond() {
+        return (REFRESH_EXPIRED_MS / 1000);
+    }
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
Related to: [[feat] 소셜 로그인 기능 구현 #7](https://github.com/Monorama-IoT-Platform/IoT-Server/issues/7)

## 📝 개요
- OAuth2 기반 구글 소셜 로그인 기능을 추가

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- OAuth2 기반 구글 로그인 연동 구현함
- JWT accessToken/refreshToken 발급 처리 포함
- 최초 로그인 시 회원가입 유도 로직 포함
- Apple 로그인은 추후 개발 예정

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [x] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.

