### PR TITLE
:sparkles: Feat: 공기질앱 공기질 데이터 저장

### DIFF
--- a/src/main/java/com/monorama/iot_server/controller/AirQuality/AirQualityDataController.java
+++ b/src/main/java/com/monorama/iot_server/controller/AirQuality/AirQualityDataController.java
@@ -1,0 +1,24 @@
+package com.monorama.iot_server.controller.AirQuality;
+
+import com.monorama.iot_server.annotation.UserId;
+import com.monorama.iot_server.dto.ResponseDto;
+import com.monorama.iot_server.dto.request.AirQuality.AirQualityDataRequestDto;
+import com.monorama.iot_server.service.AirQualityDataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/air-quality-data")
+public class AirQualityDataController {
+
+    private final AirQualityDataService airService;
+
+    @PostMapping("/realtime")
+    public ResponseEntity<ResponseDto<Void>> saveRealtime(@UserId Long userId,
+                                                          @RequestBody AirQualityDataRequestDto requestDto) {
+        airService.saveRealtime(userId, requestDto);
+        return ResponseEntity.ok(ResponseDto.ok(null));
+    }
+}

--- a/src/main/java/com/monorama/iot_server/controller/AirQuality/AirQualityDataController.java
+++ b/src/main/java/com/monorama/iot_server/controller/AirQuality/AirQualityDataController.java
@@ -5,7 +5,6 @@ import com.monorama.iot_server.dto.ResponseDto;
 import com.monorama.iot_server.dto.request.AirQuality.AirQualityDataRequestDto;
 import com.monorama.iot_server.service.AirQualityDataService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,9 +15,9 @@ public class AirQualityDataController {
     private final AirQualityDataService airService;
 
     @PostMapping("/realtime")
-    public ResponseEntity<ResponseDto<Void>> saveRealtime(@UserId Long userId,
-                                                          @RequestBody AirQualityDataRequestDto requestDto) {
+    public ResponseDto<?> saveRealtime(@UserId Long userId,
+                                       @RequestBody AirQualityDataRequestDto requestDto) {
         airService.saveRealtime(userId, requestDto);
-        return ResponseEntity.ok(ResponseDto.ok(null));
+        return ResponseDto.ok(null);
     }
 }

--- a/src/main/java/com/monorama/iot_server/domain/AirQualityData.java
+++ b/src/main/java/com/monorama/iot_server/domain/AirQualityData.java
@@ -37,8 +37,4 @@ public class AirQualityData {
     public void setAirQualityDataItem(AirQualityDataItem item) {
         this.airQualityDataItem = item;
     }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
 }

--- a/src/main/java/com/monorama/iot_server/domain/AirQualityData.java
+++ b/src/main/java/com/monorama/iot_server/domain/AirQualityData.java
@@ -29,8 +29,16 @@ public class AirQualityData {
     private User user;
 
     /*** business logic ***/
-    private void setUser(User user) {
+    public void setUser(User user) {
         this.user = user;
         user.getAirQualityDataList().add(this);
+    }
+
+    public void setAirQualityDataItem(AirQualityDataItem item) {
+        this.airQualityDataItem = item;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/monorama/iot_server/domain/embedded/AirQualityDataItem.java
+++ b/src/main/java/com/monorama/iot_server/domain/embedded/AirQualityDataItem.java
@@ -1,14 +1,18 @@
 package com.monorama.iot_server.domain.embedded;
 
+import com.monorama.iot_server.domain.type.ProjectType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Date;
+
 @Embeddable
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class AirQualityDataItem {
 
     @Column(name = "pm25_value")
@@ -52,5 +56,24 @@ public class AirQualityDataItem {
 
     @Column(name = "pico_device_longitude")
     private Double picoDeviceLongitude;
+
+    /*** constructor ***/
+    @Builder
+    public AirQualityDataItem(Double pm25Value, Integer pm25Level, Double pm10Value, Integer pm10Level, Double temperature, Integer temperatureLevel, Double humidity, Integer humidityLevel, Double co2Value, Integer co2Level, Double vocValue, Integer vocLevel, Double picoDeviceLatitude, Double picoDeviceLongitude) {
+        this.pm25Value = pm25Value;
+        this.pm25Level = pm25Level;
+        this.pm10Value = pm10Value;
+        this.pm10Level = pm10Level;
+        this.temperature = temperature;
+        this.temperatureLevel = temperatureLevel;
+        this.humidity = humidity;
+        this.humidityLevel = humidityLevel;
+        this.co2Value = co2Value;
+        this.co2Level = co2Level;
+        this.vocValue = vocValue;
+        this.vocLevel = vocLevel;
+        this.picoDeviceLatitude = picoDeviceLatitude;
+        this.picoDeviceLongitude = picoDeviceLongitude;
+    }
 }
 

--- a/src/main/java/com/monorama/iot_server/dto/request/AirQuality/AirQualityDataRequestDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/request/AirQuality/AirQualityDataRequestDto.java
@@ -1,15 +1,10 @@
 package com.monorama.iot_server.dto.request.AirQuality;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.monorama.iot_server.domain.AirQualityData;
 import com.monorama.iot_server.domain.User;
 import com.monorama.iot_server.domain.embedded.AirQualityDataItem;
 
-import java.util.Date;
-
 public record AirQualityDataRequestDto(
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        Date createAt,
         Double pm25Value,
         Integer pm25Level,
         Double pm10Value,
@@ -27,7 +22,6 @@ public record AirQualityDataRequestDto(
 ) {
     public AirQualityData toEntity(User user) {
         AirQualityData entity = new AirQualityData();
-        entity.setCreatedAt(this.createAt);
         entity.setAirQualityDataItem(
                 AirQualityDataItem.builder()
                         .pm25Value(pm25Value)

--- a/src/main/java/com/monorama/iot_server/dto/request/AirQuality/AirQualityDataRequestDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/request/AirQuality/AirQualityDataRequestDto.java
@@ -1,0 +1,52 @@
+package com.monorama.iot_server.dto.request.AirQuality;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.monorama.iot_server.domain.AirQualityData;
+import com.monorama.iot_server.domain.User;
+import com.monorama.iot_server.domain.embedded.AirQualityDataItem;
+
+import java.util.Date;
+
+public record AirQualityDataRequestDto(
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        Date createAt,
+        Double pm25Value,
+        Integer pm25Level,
+        Double pm10Value,
+        Integer pm10Level,
+        Double temperature,
+        Integer temperatureLevel,
+        Double humidity,
+        Integer humidityLevel,
+        Double co2Value,
+        Integer co2Level,
+        Double vocValue,
+        Integer vocLevel,
+        Double picoDeviceLatitude,
+        Double picoDeviceLongitude
+) {
+    public AirQualityData toEntity(User user) {
+        AirQualityData entity = new AirQualityData();
+        entity.setCreatedAt(this.createAt);
+        entity.setAirQualityDataItem(
+                AirQualityDataItem.builder()
+                        .pm25Value(pm25Value)
+                        .pm25Level(pm25Level)
+                        .pm10Value(pm10Value)
+                        .pm10Level(pm10Level)
+                        .temperature(temperature)
+                        .temperatureLevel(temperatureLevel)
+                        .humidity(humidity)
+                        .humidityLevel(humidityLevel)
+                        .co2Value(co2Value)
+                        .co2Level(co2Level)
+                        .vocValue(vocValue)
+                        .vocLevel(vocLevel)
+                        .picoDeviceLatitude(picoDeviceLatitude)
+                        .picoDeviceLongitude(picoDeviceLongitude)
+                        .build()
+        );
+        entity.setUser(user);
+        return entity;
+    }
+}

--- a/src/main/java/com/monorama/iot_server/repository/AirQualityDataRepository.java
+++ b/src/main/java/com/monorama/iot_server/repository/AirQualityDataRepository.java
@@ -1,0 +1,7 @@
+package com.monorama.iot_server.repository;
+
+import com.monorama.iot_server.domain.AirQualityData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AirQualityDataRepository extends JpaRepository<AirQualityData, Long> {
+}

--- a/src/main/java/com/monorama/iot_server/service/AirQualityDataService.java
+++ b/src/main/java/com/monorama/iot_server/service/AirQualityDataService.java
@@ -7,6 +7,7 @@ import com.monorama.iot_server.repository.AirQualityDataRepository;
 import com.monorama.iot_server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +16,7 @@ public class AirQualityDataService {
     private final UserRepository userRepo;
     private final AirQualityDataRepository airRepo;
 
+    @Transactional
     public void saveRealtime(Long userId, AirQualityDataRequestDto dto) {
         User user = userRepo.findById(userId).orElseThrow();
         AirQualityData entity = dto.toEntity(user);

--- a/src/main/java/com/monorama/iot_server/service/AirQualityDataService.java
+++ b/src/main/java/com/monorama/iot_server/service/AirQualityDataService.java
@@ -1,0 +1,23 @@
+package com.monorama.iot_server.service;
+
+import com.monorama.iot_server.domain.AirQualityData;
+import com.monorama.iot_server.domain.User;
+import com.monorama.iot_server.dto.request.AirQuality.AirQualityDataRequestDto;
+import com.monorama.iot_server.repository.AirQualityDataRepository;
+import com.monorama.iot_server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AirQualityDataService {
+
+    private final UserRepository userRepo;
+    private final AirQualityDataRepository airRepo;
+
+    public void saveRealtime(Long userId, AirQualityDataRequestDto dto) {
+        User user = userRepo.findById(userId).orElseThrow();
+        AirQualityData entity = dto.toEntity(user);
+        airRepo.save(entity);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
Related to: [[feat] 공기질 실시간 데이터 저장 API 구현 #13](https://github.com/Monorama-IoT-Platform/IoT-Server/issues/13)

## 📝 개요
- 실시간 공기질 데이터 저장 API 구현 (Request DTO, Service, Controller, Repository 포함)
- `AirQualityData`, `AirQualityDataItem` 도메인 구조 리팩토링

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- `/api/v1/air-quality-data/realtime` 엔드포인트 구현  
- `AirQualityDataRequestDto` 생성 및 `.toEntity()` 변환 로직 작성  
- `AirQualityDataService`, `AirQualityDataController` 계층 구성  
- Repository (`AirQualityDataRepository`, `UserRepository`) 추가  
- `AirQualityData`, `AirQualityDataItem` 도메인 구조 개선 (필요 메소드 추가, builder 패턴 적용)


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [x] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.

