### PR TITLE
:sparkles: Feat: 토큰 재발급 API 및 쿠키 설정 로직 추가

### DIFF
--- a/src/main/java/com/monorama/iot_server/constant/Constant.java
+++ b/src/main/java/com/monorama/iot_server/constant/Constant.java
@@ -13,6 +13,7 @@ public class Constant {
     public static final List<String> NO_NEED_AUTH_URLS = List.of(
             "/login/oauth2/code/google",
             "/oauth2/authorization/google",
+            "/api/v1/auth/refresh",
             "/favicon.ico"
     );
 }

--- a/src/main/java/com/monorama/iot_server/controller/AuthController.java
+++ b/src/main/java/com/monorama/iot_server/controller/AuthController.java
@@ -1,44 +1,89 @@
 package com.monorama.iot_server.controller;
 
 import com.monorama.iot_server.annotation.UserId;
+import com.monorama.iot_server.constant.Constant;
+import com.monorama.iot_server.dto.JwtTokenDto;
 import com.monorama.iot_server.dto.ResponseDto;
 import com.monorama.iot_server.dto.request.register.UserRegisterDto;
 import com.monorama.iot_server.dto.request.register.PMRegisterDto;
+import com.monorama.iot_server.exception.CommonException;
+import com.monorama.iot_server.exception.ErrorCode;
 import com.monorama.iot_server.service.AuthService;
+import com.monorama.iot_server.util.CookieUtil;
+import com.monorama.iot_server.util.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
-
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class AuthController {
     private final AuthService authService;
+    private final JwtUtil jwtUtil;
 
-    //소셜 회원가입
     @PatchMapping("/register/pm")
-    public ResponseDto<?> registerPM(@UserId Long userId, @RequestBody @Valid PMRegisterDto registerDto) {
-        return ResponseDto.created(authService.registerPM(userId, registerDto));
+    public ResponseDto<?> registerPM(@UserId Long userId, @RequestBody @Valid PMRegisterDto registerDto, HttpServletResponse response) {
+        JwtTokenDto tokenDto = authService.registerPM(userId, registerDto);
+        CookieUtil.addCookie(response, Constant.AUTHORIZATION, tokenDto.getAccessToken());
+        CookieUtil.addSecureCookie(response, Constant.REAUTHORIZATION, tokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
+
+        return ResponseDto.created(tokenDto);
     }
 
     @PatchMapping("/register/air-quality-data")
-    public ResponseDto<?> registerAQDUser(@UserId Long userId, @RequestBody @Valid UserRegisterDto registerDto) {
-        return ResponseDto.created(authService.registerAQDUser(userId, registerDto));
+    public ResponseDto<?> registerAQDUser(@UserId Long userId, @RequestBody @Valid UserRegisterDto registerDto, HttpServletResponse response) {
+        JwtTokenDto tokenDto = authService.registerAQDUser(userId, registerDto);
+        CookieUtil.addCookie(response, Constant.AUTHORIZATION, tokenDto.getAccessToken());
+        CookieUtil.addSecureCookie(response, Constant.REAUTHORIZATION, tokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
+
+        return ResponseDto.created(tokenDto);
     }
 
     @PatchMapping("/register/air-quality-data/role")
-    public ResponseDto<?> updateAQDToBoth(@UserId Long userId) {
-        return ResponseDto.ok(authService.updateAQDUserRole(userId));
+    public ResponseDto<?> updateAQDToBoth(@UserId Long userId, HttpServletResponse response) {
+        JwtTokenDto tokenDto = authService.updateAQDUserRole(userId);
+        CookieUtil.addCookie(response, Constant.AUTHORIZATION, tokenDto.getAccessToken());
+        CookieUtil.addSecureCookie(response, Constant.REAUTHORIZATION, tokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
+
+        return ResponseDto.created(tokenDto);
     }
 
     @PatchMapping("/register/health-data")
-    public ResponseDto<?> registerHDUser(@UserId Long userId, @RequestBody @Valid UserRegisterDto registerDto) {
-        return ResponseDto.created(authService.registerHDUser(userId, registerDto));
+    public ResponseDto<?> registerHDUser(@UserId Long userId, @RequestBody @Valid UserRegisterDto registerDto, HttpServletResponse response) {
+        JwtTokenDto tokenDto = authService.registerHDUser(userId, registerDto);
+        CookieUtil.addCookie(response, Constant.AUTHORIZATION, tokenDto.getAccessToken());
+        CookieUtil.addSecureCookie(response, Constant.REAUTHORIZATION, tokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
+
+        return ResponseDto.created(tokenDto);
     }
 
     @PatchMapping("/register/health-data/role")
-    public ResponseDto<?> updateHDToBoth(@UserId Long userId) {
-        return ResponseDto.ok(authService.updateHDUserRole(userId));
+    public ResponseDto<?> updateHDToBoth(@UserId Long userId, HttpServletResponse response) {
+        JwtTokenDto tokenDto = authService.updateHDUserRole(userId);
+        CookieUtil.addCookie(response, Constant.AUTHORIZATION, tokenDto.getAccessToken());
+        CookieUtil.addSecureCookie(response, Constant.REAUTHORIZATION, tokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
+
+        return ResponseDto.created(tokenDto);
+    }
+
+    @PatchMapping("/refresh")
+    public ResponseDto<JwtTokenDto> refresh(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = CookieUtil.getCookie(request, Constant.REAUTHORIZATION)
+                .map(Cookie::getValue)
+                .orElseThrow(()-> new CommonException(ErrorCode.TOKEN_UNKNOWN_ERROR));
+
+        log.info("refresh token : {}", refreshToken);
+        JwtTokenDto newTokens = authService.refresh(refreshToken, request);
+
+        CookieUtil.addCookie(response, Constant.AUTHORIZATION, newTokens.getAccessToken());
+        CookieUtil.addSecureCookie(response, Constant.REAUTHORIZATION, newTokens.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
+
+        return ResponseDto.ok(newTokens);
     }
 }

--- a/src/main/java/com/monorama/iot_server/repository/UserRepository.java
+++ b/src/main/java/com/monorama/iot_server/repository/UserRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<UserSecurityForm> findByIdAndIsLoginAndRefreshTokenIsNotNull(Long id, boolean b);
+    Optional<User> findUserByIdAndIsLoginAndRefreshTokenIsNotNull(Long id, boolean b);
 
     Optional<UserSecurityForm> findByRefreshToken(String refreshToken);
 

--- a/src/main/java/com/monorama/iot_server/service/AuthService.java
+++ b/src/main/java/com/monorama/iot_server/service/AuthService.java
@@ -11,6 +11,7 @@ import com.monorama.iot_server.repository.UserDataPermissonRepository;
 import com.monorama.iot_server.repository.UserRepository;
 import com.monorama.iot_server.type.ERole;
 import com.monorama.iot_server.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -94,6 +95,22 @@ public class AuthService {
         user.setRefreshToken(jwtTokenDto.getRefreshToken());
 
         return jwtTokenDto;
+    }
+
+    public JwtTokenDto refresh(String refreshToken, HttpServletRequest request) {
+        Long userId = jwtUtil.extractUserIdFromToken(refreshToken);
+
+        User user = userRepository.findUserByIdAndIsLoginAndRefreshTokenIsNotNull(userId, true)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN_ERROR));
+
+        if (!refreshToken.equals(user.getRefreshToken())) {
+            throw new CommonException(ErrorCode.TOKEN_TYPE_ERROR);
+        }
+
+        JwtTokenDto newTokens = jwtUtil.generateTokens(userId, user.getRole());
+        userRepository.updateRefreshTokenAndLoginStatus(userId, newTokens.getRefreshToken(), true);
+
+        return newTokens;
     }
 
 }

--- a/src/main/java/com/monorama/iot_server/util/CookieUtil.java
+++ b/src/main/java/com/monorama/iot_server/util/CookieUtil.java
@@ -1,18 +1,26 @@
 package com.monorama.iot_server.util;
 
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 public class CookieUtil {
-    public static Optional<Cookie> getCookie(){
-        return Optional.empty();
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst();
     }
     public static void addCookie(HttpServletResponse response, String name, String value){
         Cookie cookie = new Cookie(name,value);
         // 전역 사용
-        cookie.setPath("/");;
+        cookie.setPath("/");
 
         response.addCookie(cookie);
     }

--- a/src/main/java/com/monorama/iot_server/util/JwtUtil.java
+++ b/src/main/java/com/monorama/iot_server/util/JwtUtil.java
@@ -2,12 +2,14 @@ package com.monorama.iot_server.util;
 
 import com.monorama.iot_server.constant.Constant;
 import com.monorama.iot_server.dto.JwtTokenDto;
-import com.monorama.iot_server.repository.UserRepository;
+import com.monorama.iot_server.exception.CommonException;
+import com.monorama.iot_server.exception.ErrorCode;
 import com.monorama.iot_server.type.ERole;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -15,14 +17,12 @@ import org.springframework.stereotype.Component;
 import java.security.Key;
 import java.util.Date;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtUtil implements InitializingBean {
-    private static final Integer ACCESS_EXPIRED_MS = 2 * 60 * 60 * 1000;
+    private static final Integer ACCESS_EXPIRED_MS = 60 * 60 * 1000;
     private static final Integer REFRESH_EXPIRED_MS = 7 * 24 * 60 * 60 * 1000;
-
-
-    private final UserRepository userRepository;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -34,9 +34,16 @@ public class JwtUtil implements InitializingBean {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
+//    public JwtTokenDto generateTokens(Long id, ERole eRole) {
+//        return new JwtTokenDto(generateAccessToken(id, eRole, ACCESS_EXPIRED_MS),
+//                generateToken(null, REFRESH_EXPIRED_MS));
+//    }
+
     public JwtTokenDto generateTokens(Long id, ERole eRole) {
-        return new JwtTokenDto(generateAccessToken(id, eRole, ACCESS_EXPIRED_MS),
-                generateToken(null, REFRESH_EXPIRED_MS));
+        return new JwtTokenDto(
+                generateAccessToken(id, eRole, ACCESS_EXPIRED_MS),
+                generateRefreshToken(id)
+        );
     }
 
     public Claims validateToken(final String token) throws JwtException {
@@ -54,12 +61,30 @@ public class JwtUtil implements InitializingBean {
                 .compact();
     }
 
+    public String generateRefreshToken(Long id) {
+        final Claims claims = Jwts.claims();
+        claims.put(Constant.USER_ID_CLAIM_NAME, id.toString());
+
+        return generateToken(claims, REFRESH_EXPIRED_MS);
+    }
+
     public String generateAccessToken(final Long id, final ERole role, final Integer expirationPeriod) {
         final Claims claims = Jwts.claims();
         claims.put(Constant.USER_ID_CLAIM_NAME, id.toString());
         claims.put(Constant.USER_ROLE_CLAIM_NAME, role.toString());
 
         return generateToken(claims, expirationPeriod);
+    }
+
+    public Long extractUserIdFromToken(String token) {
+        try {
+            Claims claims = validateToken(token);
+            String userIdStr = claims.get(Constant.USER_ID_CLAIM_NAME, String.class);
+            return Long.valueOf(userIdStr);
+        } catch (Exception e) {
+            log.warn("유효하지 않은 토큰입니다: {}", e.getMessage());
+            throw new CommonException(ErrorCode.INVALID_TOKEN_ERROR);
+        }
     }
 
     public int getAccessTokenExpriration() {


### PR DESCRIPTION
## 🔗 관련 이슈
- Related to: #7 

## 📝 개요
- 사용자 인증 완료 이후 access/refresh token을 쿠키에 설정하도록 구현함
- refresh token 기반 access token 재발급 기능을 추가함

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- /api/v1/auth/refresh PATCH API 구현
- CookieUtil.getCookie 로직 구현
- access/refresh token을 addCookie 및 addSecureCookie로 설정
- PM / AQD / HD 등록 및 역할 병합 로직에도 동일한 쿠키 처리 적용


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [x] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.

