### PR TITLE
✨ Feat: 사용자 권한 정보 스케줄러

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,7 @@ out/
 .DS_Store
 
 
-### yml ###
+### resource ###
 **/*.yml
+**/*.p12
+**/*.p8

--- a/src/main/java/com/monorama/iot_server/config/SchedulerConfig.java
+++ b/src/main/java/com/monorama/iot_server/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.monorama.iot_server.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/monorama/iot_server/config/SecurityConfig.java
+++ b/src/main/java/com/monorama/iot_server/config/SecurityConfig.java
@@ -66,9 +66,10 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(requestMatcherRegistry -> requestMatcherRegistry
                         .requestMatchers("/api/v1/auth/**").permitAll()
-                        .requestMatchers("/projects/**").hasAnyRole((ERole.PM.toString()),ERole.BOTH_USER.toString(), ERole.AQD_USER.toString(), ERole.HD_USER.toString())
-                        .requestMatchers("/health-data/**").hasAnyRole((ERole.BOTH_USER.toString()),ERole.HD_USER.toString())
-                        .requestMatchers("/air-quality-data/**").hasAnyRole((ERole.BOTH_USER.toString()), ERole.AQD_USER.toString())
+                        .requestMatchers("/api/v1/metadata/**").hasAnyRole((ERole.PM.toString()),ERole.BOTH_USER.toString(), ERole.AQD_USER.toString())
+                        .requestMatchers("/api/v1/projects/**").hasAnyRole((ERole.PM.toString()),ERole.BOTH_USER.toString(), ERole.AQD_USER.toString(), ERole.HD_USER.toString())
+                        .requestMatchers("/api/v1/health-data/**").hasAnyRole((ERole.BOTH_USER.toString()),ERole.HD_USER.toString())
+                        .requestMatchers("/api/v1/air-quality-data/**").hasAnyRole((ERole.BOTH_USER.toString()), ERole.AQD_USER.toString())
                         .anyRequest().authenticated())
 
                 .oauth2Login(

--- a/src/main/java/com/monorama/iot_server/repository/UserProjectRepository.java
+++ b/src/main/java/com/monorama/iot_server/repository/UserProjectRepository.java
@@ -4,8 +4,20 @@ import com.monorama.iot_server.domain.Project;
 import com.monorama.iot_server.domain.User;
 import com.monorama.iot_server.domain.UserProject;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Date;
+import java.util.List;
 
 public interface UserProjectRepository extends JpaRepository<UserProject, Long> {
     Boolean existsByUserAndProject(User user, Project project);
+
+    @Query("SELECT up.project FROM UserProject up " +
+            "WHERE up.user.id = :userId " +
+            "AND up.project.startDate <= :today " +
+            "AND up.project.endDate >= :today")
+    List<Project> findProgressProjectsByUserId(@Param("userId") Long userId, @Param("today") Date today);
+
 }
 

--- a/src/main/java/com/monorama/iot_server/service/PermissionUpdateService.java
+++ b/src/main/java/com/monorama/iot_server/service/PermissionUpdateService.java
@@ -1,0 +1,54 @@
+package com.monorama.iot_server.service;
+
+import com.monorama.iot_server.domain.embedded.AirQualityDataFlag;
+import com.monorama.iot_server.domain.embedded.HealthDataFlag;
+import com.monorama.iot_server.domain.embedded.PersonalInfoFlag;
+import com.monorama.iot_server.repository.ProjectRepository;
+import com.monorama.iot_server.repository.UserDataPermissionRepository;
+import com.monorama.iot_server.repository.UserProjectRepository;
+import com.monorama.iot_server.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PermissionUpdateService {
+
+    private final UserDataPermissionRepository userDataPermissionRepository;
+    private final UserProjectRepository userProjectRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void refreshUserPermission() {
+
+        Date today = Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
+        userDataPermissionRepository.findAll().forEach(userDataPermission -> {
+
+            PersonalInfoFlag personalInfoFlag = new PersonalInfoFlag();
+            AirQualityDataFlag airQualityDataFlag = new AirQualityDataFlag();
+            HealthDataFlag healthDataFlag = new HealthDataFlag();
+
+            userProjectRepository.findProgressProjectsByUserId(
+                    userDataPermission.getUser().getId(),
+                    today
+            ).forEach(project -> {
+                personalInfoFlag.updateBy(project.getPersonalInfoFlag());
+                airQualityDataFlag.updateBy(project.getAirQualityDataFlag());
+                healthDataFlag.updateBy(project.getHealthDataFlag());
+            });
+
+            userDataPermission.getAirQualityDataFlag().updateBy(airQualityDataFlag);
+            userDataPermission.getHealthDataFlag().updateBy(healthDataFlag);
+            userDataPermission.getPersonalInfoFlag().updateBy(personalInfoFlag);
+        } );
+    }
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolves: #34 

## 📝 개요
- 사용자 참여 프로젝트 기준으로 UserDataPermission을 매일 자정 기준으로 갱신하는 기능 추가
- end point 수정

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- @Scheduled 기반 PermissionUpdateService 구현함
- 현재 날짜에 유효한 프로젝트의 flag들을 병합하여 UserDataPermission에 반영되도록 처리함
- 기존 true 값 초기화를 위해 새 객체 생성 후 set 방식으로 덮어씀
- SecurityConfig에 잘못된 endpoint 수정
- git ignore에 p12, p8 추가

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [x] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.

