### PR TITLE
:sparkles: Feat: CORS 설정 및 인증 로직 설정값 외부화 리팩토링

### DIFF
--- a/src/main/java/com/monorama/iot_server/config/CorsConfig.java
+++ b/src/main/java/com/monorama/iot_server/config/CorsConfig.java
@@ -1,0 +1,31 @@
+package com.monorama.iot_server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Value("${monorama.cors.allowed-origins}")
+    private String allowedOrigins;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(allowedOrigins));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        config.setExposedHeaders(List.of("Authorization"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/com/monorama/iot_server/config/SecurityConfig.java
+++ b/src/main/java/com/monorama/iot_server/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,8 +31,6 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 @RequiredArgsConstructor
 @Slf4j
 public class SecurityConfig {
-    private final DefaultSuccessHandler defaultSuccessHandler;
-    private final DefaultFailureHandler defaultFailureHandler;
 
     private final CustomUserDetailService customUserDetailService;
     private final CustomOAuth2UserService customOAuth2UserService;
@@ -59,6 +58,7 @@ public class SecurityConfig {
     @Bean
     protected SecurityFilterChain securityFilterChain(final HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -100,5 +100,4 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class)
                 .getOrBuild();
     }
-
 }

--- a/src/main/java/com/monorama/iot_server/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/monorama/iot_server/security/filter/JwtAuthenticationFilter.java
@@ -35,6 +35,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws JwtException, ServletException, IOException {
 
+        log.info("JwtAuthenticationFilter doFilterInternal");
+        log.info("request.getRequestURI() : {}", request.getRequestURI());
+        log.info("request.getHeader(Authorization) : {}", request.getHeader(Constant.AUTHORIZATION_HEADER));
+
         final String token = HeaderUtil.refineHeader(request,Constant.AUTHORIZATION_HEADER,Constant.BEARER_PREFIX)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN_ERROR));
 

--- a/src/main/java/com/monorama/iot_server/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/monorama/iot_server/security/handler/OAuth2LoginSuccessHandler.java
@@ -14,7 +14,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.core.Authentication;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -24,8 +26,12 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @Slf4j
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
+
+    @Value("${monorama.redirect.base-url}")
+    private String redirectBaseUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException, ServletException {
@@ -36,19 +42,14 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     @Transactional
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
-
         JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(userPrincipal.getId(), userPrincipal.getRole());
-        userRepository.updateRefreshTokenAndLoginStatus(userPrincipal.getId(), jwtTokenDto.getRefreshToken(),Boolean.TRUE);
+        userRepository.updateRefreshTokenAndLoginStatus(userPrincipal.getId(), jwtTokenDto.getRefreshToken(), Boolean.TRUE);
 
-        CookieUtil.addCookie(response, Constant.AUTHORIZATION, jwtTokenDto.getAccessToken());
         CookieUtil.addSecureCookie(response, Constant.REAUTHORIZATION, jwtTokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
-
-        // Guest 즉, 소셜로그인으로 방금 가입한 유저는 따로 로직 분류
-
         if (userPrincipal.getRole().equals(ERole.GUEST)) {
-            response.sendRedirect( "http://localhost:5173/auth/register/social_" + jwtTokenDto.getAccessToken());
+            response.sendRedirect( redirectBaseUrl + "/auth/register/social" + "?accessToken=" + jwtTokenDto.getAccessToken());
         } else {
-            response.sendRedirect("http://localhost:5173/_" + jwtTokenDto.getAccessToken());
+            response.sendRedirect(redirectBaseUrl + "/projects" + "?accessToken=" + jwtTokenDto.getAccessToken());
         }
 
     }

--- a/src/main/java/com/monorama/iot_server/util/CookieUtil.java
+++ b/src/main/java/com/monorama/iot_server/util/CookieUtil.java
@@ -26,10 +26,15 @@ public class CookieUtil {
     }
 
     public static void addSecureCookie(HttpServletResponse response,String name, String value, Integer maxAge){
-        Cookie cookie = new Cookie(name,value);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
+//        Cookie cookie = new Cookie(name,value);
+//        cookie.setPath("/");
+//        cookie.setHttpOnly(true);
+//        cookie.setMaxAge(maxAge);
+//        cookie.setSecure(true);
+//        response.addCookie(cookie);
+        response.setHeader("Set-Cookie", String.format(
+                "%s=%s; Path=/; Max-Age=%d; HttpOnly; Secure; SameSite=None",
+                name, value, maxAge
+        ));
     }
 }

--- a/src/main/java/com/monorama/iot_server/util/JwtUtil.java
+++ b/src/main/java/com/monorama/iot_server/util/JwtUtil.java
@@ -21,9 +21,10 @@ import java.util.Date;
 @Component
 @RequiredArgsConstructor
 public class JwtUtil implements InitializingBean {
-    private static final Integer ACCESS_EXPIRED_MS = 60 * 60 * 1000;
-    private static final Integer REFRESH_EXPIRED_MS = 7 * 24 * 60 * 60 * 1000;
-
+    @Value("${jwt.access-expiration-ms}")
+    private Integer ACCESS_EXPIRED_MS;
+    @Value("${jwt.refresh-expiration-ms}")
+    private Integer REFRESH_EXPIRED_MS;
     @Value("${jwt.secret}")
     private String secretKey;
     private Key key;


### PR DESCRIPTION
## 🔗 관련 이슈

## 📝 개요
- 인증 처리 및 보안 설정을 개선하고, 중복 로직을 리팩토링

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- CORS 설정을 별도 Config 클래스로 분리하고 yml로 관리하도록 변경
- 공통된 쿠키 설정 로직을 AuthController에서 메서드로 추출하여 중복 제거  
- JWT 발급 시 SameSite=None 속성 적용
- JwtAuthenticationFilter에 디버깅을 위한 요청 로그 출력 추가
- OAuth2LoginSuccessHandler와 JwtUtil에서 @Value로 설정값을 주입받도록 수정하여 yml 기반 설정으로 전환

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [x] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.

