### PR TITLE
✨  Feat: ProjectDetail 응답 스키마 확장 및 약관 필드 추가함

### DIFF
--- a/src/main/java/com/monorama/iot_server/controller/AuthController.java
+++ b/src/main/java/com/monorama/iot_server/controller/AuthController.java
@@ -42,15 +42,13 @@ public class AuthController {
     }
 
     @PatchMapping("/register/air-quality-data")
-    public ResponseDto<?> registerAQDUser(@UserId Long userId, @RequestBody @Valid UserRegisterDto registerDto, HttpServletResponse response) {
-        JwtTokenDto tokenDto = authService.registerAQDUser(userId, registerDto);
-        return handleAccessTokenAndSetCookie(tokenDto, response);
+    public ResponseDto<JwtTokenDto> registerAQDUser(@UserId Long userId, @RequestBody @Valid UserRegisterDto registerDto) {
+        return ResponseDto.ok(authService.registerAQDUser(userId, registerDto));
     }
 
     @PatchMapping("/register/air-quality-data/role")
-    public ResponseDto<?> updateAQDToBoth(@UserId Long userId, HttpServletResponse response) {
-        JwtTokenDto tokenDto = authService.updateAQDUserRole(userId);
-        return handleAccessTokenAndSetCookie(tokenDto, response);
+    public ResponseDto<JwtTokenDto> updateAQDToBoth(@UserId Long userId) {
+        return ResponseDto.ok(authService.updateAQDUserRole(userId));
     }
 
     @PatchMapping("/register/health-data")
@@ -59,9 +57,8 @@ public class AuthController {
     }
 
     @PatchMapping("/register/health-data/role")
-    public ResponseDto<?> updateHDToBoth(@UserId Long userId, HttpServletResponse response) {
-        JwtTokenDto tokenDto = authService.updateHDUserRole(userId);
-        return handleAccessTokenAndSetCookie(tokenDto, response);
+    public ResponseDto<JwtTokenDto> updateHDToBoth(@UserId Long userId) {
+        return ResponseDto.ok(authService.updateHDUserRole(userId));
     }
 
     @PatchMapping("/refresh")

--- a/src/main/java/com/monorama/iot_server/domain/User.java
+++ b/src/main/java/com/monorama/iot_server/domain/User.java
@@ -95,6 +95,10 @@ public class User {
         this.role = ERole.BOTH_USER;
     }
 
+    public String getEmail() {
+        return personalInfo.getEmail();
+    }
+
     private void setUserDataPermission(UserDataPermission userDataPermission) {
         this.userDataPermission = userDataPermission;
     }

--- a/src/main/java/com/monorama/iot_server/dto/response/project/AirMetaDataItemResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/project/AirMetaDataItemResponseDto.java
@@ -1,0 +1,16 @@
+package com.monorama.iot_server.dto.response.project;
+
+import com.monorama.iot_server.domain.AirMetaDataItem;
+import com.monorama.iot_server.domain.type.DataType;
+
+public record AirMetaDataItemResponseDto(
+        String dataName,
+        DataType dataType
+) {
+    public static AirMetaDataItemResponseDto fromEntity(AirMetaDataItem airMetaDataItem) {
+        return new AirMetaDataItemResponseDto(
+                airMetaDataItem.getDataName(),
+                airMetaDataItem.getDataType()
+        );
+    }
+}

--- a/src/main/java/com/monorama/iot_server/dto/response/project/ProjectDetailResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/project/ProjectDetailResponseDto.java
@@ -7,6 +7,7 @@ import com.monorama.iot_server.domain.embedded.HealthDataFlag;
 import com.monorama.iot_server.domain.embedded.PersonalInfoFlag;
 
 import java.util.Date;
+import java.util.List;
 
 public record ProjectDetailResponseDto(
         String pmEmail,
@@ -23,6 +24,12 @@ public record ProjectDetailResponseDto(
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         Date createdAt,
+
+        String termsOfPolicy,
+        String privacyPolicy,
+        String healthDataConsent,
+        String airDataConsent,
+        String localDataTermsOfService,
 
         Boolean email,
         Boolean gender,
@@ -61,9 +68,14 @@ public record ProjectDetailResponseDto(
         Boolean vocValue,
         Boolean vocLevel,
         Boolean picoDeviceLatitude,
-        Boolean picoDeviceLongitude
+        Boolean picoDeviceLongitude,
+
+        List<AirMetaDataItemResponseDto> airMetaDataItemList
 ) {
-    public static ProjectDetailResponseDto fromEntity(Project project) {
+    public static ProjectDetailResponseDto fromEntity(
+            Project project,
+            List<AirMetaDataItemResponseDto> airMetaDataItemDtoList
+    ) {
         PersonalInfoFlag p = project.getPersonalInfoFlag();
         HealthDataFlag h = project.getHealthDataFlag();
         AirQualityDataFlag a = project.getAirQualityDataFlag();
@@ -77,6 +89,12 @@ public record ProjectDetailResponseDto(
                 project.getStartDate(),
                 project.getEndDate(),
                 project.getCreatedAt(),
+
+                project.getTermsOfPolicy(),
+                project.getPrivacyPolicy(),
+                project.getHealthDataConsent(),
+                project.getAirDataConsent(),
+                project.getLocalDataTermsOfService(),
 
                 p.getEmail(),
                 p.getGender(),
@@ -115,7 +133,9 @@ public record ProjectDetailResponseDto(
                 a.getVocValue(),
                 a.getVocLevel(),
                 a.getPicoDeviceLatitude(),
-                a.getPicoDeviceLongitude()
+                a.getPicoDeviceLongitude(),
+
+                airMetaDataItemDtoList
         );
     }
 }

--- a/src/main/java/com/monorama/iot_server/dto/response/project/ProjectDetailResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/project/ProjectDetailResponseDto.java
@@ -9,6 +9,7 @@ import com.monorama.iot_server.domain.embedded.PersonalInfoFlag;
 import java.util.Date;
 
 public record ProjectDetailResponseDto(
+        String pmEmail,
         String projectTitle,
         Integer participant,
         String description,
@@ -68,6 +69,7 @@ public record ProjectDetailResponseDto(
         AirQualityDataFlag a = project.getAirQualityDataFlag();
 
         return new ProjectDetailResponseDto(
+                project.getUser().getEmail(),
                 project.getTitle(),
                 project.getParticipant(),
                 project.getDescription(),

--- a/src/main/java/com/monorama/iot_server/dto/response/project/ProjectSimpleResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/project/ProjectSimpleResponseDto.java
@@ -4,9 +4,17 @@ import com.monorama.iot_server.domain.Project;
 
 public record ProjectSimpleResponseDto(
         Long projectId,
-        String projectTitle
+        String projectTitle,
+        String termsOfPolicy,
+        String privacyPolicy,
+        String healthDataConsent,
+        String airDataConsent,
+        String localDataTermsOfService
 ) {
     public static ProjectSimpleResponseDto fromEntity(Project project) {
-        return new ProjectSimpleResponseDto(project.getId(), project.getTitle());
+        return new ProjectSimpleResponseDto(project.getId(), project.getTitle(),
+                project.getTermsOfPolicy(), project.getPrivacyPolicy(),
+                project.getHealthDataConsent(), project.getAirDataConsent(),
+                project.getLocalDataTermsOfService());
     }
 }

--- a/src/main/java/com/monorama/iot_server/service/AuthService.java
+++ b/src/main/java/com/monorama/iot_server/service/AuthService.java
@@ -40,7 +40,7 @@ public class AuthService {
                             .socialId(socialId)
                             .provider(EProvider.APPLE)
                             .build();
-                    return userRepository.save(newUser); // 저장된 유저 객체 반환
+                    return userRepository.save(newUser);
                 });
 
         JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(user.getId(), user.getRole());

--- a/src/main/java/com/monorama/iot_server/service/airquality/AQDProjectService.java
+++ b/src/main/java/com/monorama/iot_server/service/airquality/AQDProjectService.java
@@ -5,6 +5,7 @@ import com.monorama.iot_server.domain.User;
 import com.monorama.iot_server.domain.UserDataPermission;
 import com.monorama.iot_server.domain.UserProject;
 import com.monorama.iot_server.domain.type.TermsType;
+import com.monorama.iot_server.dto.response.project.AirMetaDataItemResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectDetailResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectListResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectSimpleResponseDto;
@@ -12,6 +13,7 @@ import com.monorama.iot_server.dto.response.terms.TermsContentResponseDto;
 import com.monorama.iot_server.exception.CommonException;
 import com.monorama.iot_server.exception.ErrorCode;
 import com.monorama.iot_server.repository.AQDProjectRepository;
+import com.monorama.iot_server.repository.AirMetaDataItemRepository;
 import com.monorama.iot_server.repository.UserProjectRepository;
 import com.monorama.iot_server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class AQDProjectService {
     private final AQDProjectRepository aqdProjectRepo;
     private final UserRepository userRepo;
     private final UserProjectRepository userProjectRepo;
+    private final AirMetaDataItemRepository airMetaDataItemRepository;
 
     public ProjectListResponseDto getAvailableAirQualityProjectList() {
         List<ProjectSimpleResponseDto> projects = aqdProjectRepo.findActiveAirQualityProjects()
@@ -43,7 +46,12 @@ public class AQDProjectService {
         Project project = aqdProjectRepo.findById(projectId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PROJECT));
 
-        return ProjectDetailResponseDto.fromEntity(project);
+        List<AirMetaDataItemResponseDto> airMetaDataItemDtoList = airMetaDataItemRepository.findAllByProjectId(project.getId())
+                .stream()
+                .map(AirMetaDataItemResponseDto::fromEntity)
+                .toList();
+
+        return ProjectDetailResponseDto.fromEntity(project, airMetaDataItemDtoList);
     }
 
     public TermsContentResponseDto getTermsContent(Long projectId, TermsType type) {

--- a/src/main/java/com/monorama/iot_server/service/healthdata/HDProjectService.java
+++ b/src/main/java/com/monorama/iot_server/service/healthdata/HDProjectService.java
@@ -5,11 +5,13 @@ import com.monorama.iot_server.domain.User;
 import com.monorama.iot_server.domain.UserDataPermission;
 import com.monorama.iot_server.domain.UserProject;
 import com.monorama.iot_server.domain.type.TermsType;
+import com.monorama.iot_server.dto.response.project.AirMetaDataItemResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectDetailResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectListResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectSimpleResponseDto;
 import com.monorama.iot_server.dto.response.terms.TermsContentResponseDto;
 import com.monorama.iot_server.exception.CommonException;
+import com.monorama.iot_server.repository.AirMetaDataItemRepository;
 import com.monorama.iot_server.repository.ProjectRepository;
 import com.monorama.iot_server.repository.UserProjectRepository;
 import com.monorama.iot_server.repository.UserRepository;
@@ -29,6 +31,7 @@ public class HDProjectService {
     private final ProjectRepository projectRepository;
     private final UserRepository userRepository;
     private final UserProjectRepository userProjectRepository;
+    private final AirMetaDataItemRepository airMetaDataItemRepository;
 
     public ProjectListResponseDto getAvailableHealthProjectList() {
         List<ProjectSimpleResponseDto> projects = projectRepository.findActiveHealthProjects()
@@ -42,7 +45,13 @@ public class HDProjectService {
     public ProjectDetailResponseDto getProjectDetail(Long projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PROJECT));
-        return ProjectDetailResponseDto.fromEntity(project);
+
+        List<AirMetaDataItemResponseDto> airMetaDataItemDtoList = airMetaDataItemRepository.findAllByProjectId(project.getId())
+                .stream()
+                .map(AirMetaDataItemResponseDto::fromEntity)
+                .toList();
+
+        return ProjectDetailResponseDto.fromEntity(project, airMetaDataItemDtoList);
     }
 
     public TermsContentResponseDto getTermsContent(Long projectId, TermsType type) {

--- a/src/main/java/com/monorama/iot_server/service/pm/PMService.java
+++ b/src/main/java/com/monorama/iot_server/service/pm/PMService.java
@@ -3,11 +3,13 @@ package com.monorama.iot_server.service.pm;
 import com.monorama.iot_server.domain.Project;
 import com.monorama.iot_server.domain.User;
 import com.monorama.iot_server.dto.request.pm.ProjectRequestDto;
+import com.monorama.iot_server.dto.response.project.AirMetaDataItemResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectDetailResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectListForPMResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectSimpleForPMResponseDto;
 import com.monorama.iot_server.exception.CommonException;
 import com.monorama.iot_server.exception.ErrorCode;
+import com.monorama.iot_server.repository.AirMetaDataItemRepository;
 import com.monorama.iot_server.repository.ProjectRepository;
 import com.monorama.iot_server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class PMService {
 
     private final UserRepository userRepository;
     private final ProjectRepository projectRepository;
+    private final AirMetaDataItemRepository airMetaDataItemRepository;
 
     public ProjectListForPMResponseDto getProjectList(Long pmId) {
         List<ProjectSimpleForPMResponseDto> projects = projectRepository.findAllByPMId(pmId)
@@ -34,7 +37,12 @@ public class PMService {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PROJECT));
 
-        return ProjectDetailResponseDto.fromEntity(project);
+        List<AirMetaDataItemResponseDto> airMetaDataItemDtoList = airMetaDataItemRepository.findAllByProjectId(project.getId())
+                .stream()
+                .map(AirMetaDataItemResponseDto::fromEntity)
+                .toList();
+
+        return ProjectDetailResponseDto.fromEntity(project, airMetaDataItemDtoList);
     }
 
     public void saveProject(Long pmId, ProjectRequestDto projectRequestDto) {


### PR DESCRIPTION
## 🔗 관련 이슈
- 없음

## 📝 개요
- PM 웹에서 프로젝트 상세 정보 조회 시 누락된 약관과 메타데이터 필드를 포함하도록 응답 스키마를 확장함

## 🧩 PR 유형
- [x] 기능 추가
- [x] 리팩토링 (기능 변경 없음)

## ✅ 상세 내용
- `ProjectDetailResponseDto`에 `pmEmail` 필드 추가함
- `ProjectDetail` 응답 객체에 누락된 약관 항목과 메타데이터 항목 포함하도록 수정함
- 앱 유저 등록 시 반환 타입 통일성을 위해 반환 구조 리팩토링함
- 불필요한 주석 제거함

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 테스트가 통과되었습니다.
- [x] 문서가 반영되었습니다.
- [x] 민감 정보가 포함되지 않았습니다.
- [x] 불필요한 코드/로그가 제거되었습니다.
