### PR TITLE
:sparkles: Feat: 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/monorama/iot_server/controller/AuthController.java
+++ b/src/main/java/com/monorama/iot_server/controller/AuthController.java
@@ -72,6 +72,12 @@ public class AuthController {
         return handleAccessTokenAndSetCookie(newTokens, response);
     }
 
+    @DeleteMapping("/withdraw")
+    public ResponseDto<?> withdrawUser(@UserId Long userId) {
+        authService.withdrawUser(userId);
+        return ResponseDto.ok(null);
+    }
+
     private ResponseDto<?> handleAccessTokenAndSetCookie(JwtTokenDto tokenDto, HttpServletResponse response) {
         CookieUtil.addSecureCookie(
                 response,

--- a/src/main/java/com/monorama/iot_server/domain/User.java
+++ b/src/main/java/com/monorama/iot_server/domain/User.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -16,6 +17,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
+@DynamicUpdate
 @Table(name = "user_tb")
 public class User {
 
@@ -101,5 +103,13 @@ public class User {
 
     private void setUserDataPermission(UserDataPermission userDataPermission) {
         this.userDataPermission = userDataPermission;
+    }
+
+    public void withdrawUser() {
+        this.isLogin = false;
+        this.socialId = null;
+        this.refreshToken = null;
+        this.personalInfo.withdraw();
+        this.role = ERole.WITHDRAWN;
     }
 }

--- a/src/main/java/com/monorama/iot_server/domain/embedded/PersonalInfoItem.java
+++ b/src/main/java/com/monorama/iot_server/domain/embedded/PersonalInfoItem.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -49,5 +48,12 @@ public class PersonalInfoItem {
 
     @Column(name = "weight")
     private Double weight;
+
+    public void withdraw() {
+        this.name = null;
+        this.email = null;
+        this.phoneNumber = null;
+        this.nationalCode = null;
+    }
 }
 

--- a/src/main/java/com/monorama/iot_server/service/AuthService.java
+++ b/src/main/java/com/monorama/iot_server/service/AuthService.java
@@ -124,6 +124,7 @@ public class AuthService {
         return jwtTokenDto;
     }
 
+    @Transactional
     public JwtTokenDto refresh(String refreshToken, HttpServletRequest request) {
         Long userId = jwtUtil.extractUserIdFromToken(refreshToken);
 
@@ -140,4 +141,11 @@ public class AuthService {
         return newTokens;
     }
 
+    @Transactional
+    public void withdrawUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
+
+        user.withdrawUser();
+    }
 }

--- a/src/main/java/com/monorama/iot_server/type/ERole.java
+++ b/src/main/java/com/monorama/iot_server/type/ERole.java
@@ -9,8 +9,8 @@ public enum ERole {
     AQD_USER("AQD_USER", "ROLE_AQD_USER"),
     BOTH_USER("BOTH_USER", "ROLE_BOTH_USER"),
     ADMIN("ADMIN", "ROLE_ADMIN"),
-    GUEST("GUEST", "ROLE_GUEST");
-
+    GUEST("GUEST", "ROLE_GUEST"),
+    WITHDRAWN("WITHDRAWN", "ROLE_WITHDRAWN");
     private final String name;
     private final String securityName;
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolves: #46 

## 📝 개요
- 회원 탈퇴 요청 시 직접 식별자(socialId, 이메일, 전화번호 등)를 null 처리하여 사용자 식별을 불가능하게 만드는 기능을 구현함

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- `User` 엔티티에 `withdrawUser()` 도메인 메서드 추가
- 내부에서 `socialId`, `refreshToken`, `isLogin` 필드 null 또는 false로 처리
- `personalInfo` 객체 내부에서 `name`, `email`, `phoneNumber`, `nationalCode`를 null 처리하는 `withdraw()` 메서드 구현
- `role`을 `WITHDRAWN`으로 변경하여 탈퇴 사용자 상태 표현
- `@DynamicUpdate` 적용으로 변경된 컬럼만 반영되도록 최적화

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [ ] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [x] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.

