### PR TITLE
:sparkles: Feat: 회원가입 시 약관 조회 기능 구현

### DIFF
--- a/src/main/java/com/monorama/iot_server/controller/airquality/AQDSignUpTermsController.java
+++ b/src/main/java/com/monorama/iot_server/controller/airquality/AQDSignUpTermsController.java
@@ -1,0 +1,24 @@
+package com.monorama.iot_server.controller.airquality;
+
+import com.monorama.iot_server.domain.type.ServiceType;
+import com.monorama.iot_server.dto.ResponseDto;
+import com.monorama.iot_server.dto.response.terms.SignUpTermsListResponseDto;
+import com.monorama.iot_server.service.SignUpTermsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth/air-quality-data/terms")
+@RequiredArgsConstructor
+public class AQDSignUpTermsController {
+
+    private final SignUpTermsService signUpTermsService;
+
+    @GetMapping
+    public ResponseDto<SignUpTermsListResponseDto> getTerms() {
+        SignUpTermsListResponseDto result = signUpTermsService.getTermsByProjectType(ServiceType.AIR_QUALITY);
+        return ResponseDto.ok(result);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #49

## 📝 개요
- Air Quality 앱에서 회원 가입 시에 약관을 불러오는 API 구현

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- HDSignUpTermsController.java와 같은 구조로 구현함


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.

