### PR TITLE
:wrench: Chore: 배포 환경 URL을 monodatum.io 로 수정함 (Release 브랜치 병합)

### DIFF
--- a/.github/workflows/spring-cicd.yml
+++ b/.github/workflows/spring-cicd.yml
@@ -10,13 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout with submodules
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: "21"
+          distribution: "temurin"
 
       - name: Build with Gradle
         run: ./gradlew clean build -x test
@@ -38,5 +42,5 @@ jobs:
           key: ${{ secrets.EC2_KEY }}
           script: |
             cd ~/Monorama-IoT
-            docker-compose pull spring
-            docker-compose up -d
+            sudo docker-compose pull spring
+            sudo docker-compose up -d

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.java.home=C:\\Program Files\\Java\\jdk-21
+#org.gradle.java.home=C:\\Program Files\\Java\\jdk-21


### PR DESCRIPTION
## 🔗 관련 이슈
- 없음

## 📝 개요
- IoT Secret 서브 레포지토리의 `application-prod.yml` 파일에서 운영 환경 URL을 실제 서비스 도메인(`monodatum.io`)으로 수정함

## 🧩 PR 유형 (중복 선택 가능)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [x] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- `application-prod.yml` 내 기존 URL(`sssungjin.site`)을 `monodatum.io` 로 변경함  
- 운영 배포 환경에서 실제 서비스 도메인을 사용하도록 수정함  
- 개발 테스트 환경은 기존 도메인(`sssungjin.site`) 유지함  

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.
