### PR TITLE
Feature/80 공기질 참가 프로젝트 히스토리 조회 기능

### DIFF
--- a/src/main/java/com/monorama/iot_server/controller/airquality/AQDHistoryController.java
+++ b/src/main/java/com/monorama/iot_server/controller/airquality/AQDHistoryController.java
@@ -1,0 +1,36 @@
+package com.monorama.iot_server.controller.airquality;
+
+import com.monorama.iot_server.annotation.UserId;
+import com.monorama.iot_server.dto.ResponseDto;
+import com.monorama.iot_server.dto.response.airquality.AQDHistoryListResponseDto;
+import com.monorama.iot_server.service.airquality.AQDHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/air-quality-data")
+public class AQDHistoryController {
+
+    private final AQDHistoryService airQualityHistoryService;
+
+    @GetMapping("/history")
+    public ResponseDto<AQDHistoryListResponseDto> getHistory(
+            @UserId Long userId,
+            @RequestParam("projectId") Long projectId,
+            @RequestParam("date") String date,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "100") int size
+    ) {
+        LocalDate localDate = LocalDate.parse(date);
+
+        AQDHistoryListResponseDto data = airQualityHistoryService.getHistory(projectId, userId, localDate, page, size);
+
+        return ResponseDto.ok(data);
+    }
+}

--- a/src/main/java/com/monorama/iot_server/controller/airquality/AQDProjectController.java
+++ b/src/main/java/com/monorama/iot_server/controller/airquality/AQDProjectController.java
@@ -2,6 +2,7 @@ package com.monorama.iot_server.controller.airquality;
 
 import com.monorama.iot_server.annotation.UserId;
 import com.monorama.iot_server.dto.ResponseDto;
+import com.monorama.iot_server.dto.response.airquality.AQDParticipatedProjectListResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectDetailResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectListResponseDto;
 import com.monorama.iot_server.service.airquality.AQDProjectService;
@@ -18,6 +19,15 @@ public class AQDProjectController {
     @GetMapping("/projects")
     public ResponseDto<ProjectListResponseDto> getAllProjects(@UserId Long userId) {
         return ResponseDto.ok(aqdProjectService.getAvailableAQDList(userId));
+    }
+
+    @GetMapping("/projects/participation")
+    public ResponseDto<AQDParticipatedProjectListResponseDto> getParticipatedProjects(
+            @UserId Long userId
+    ) {
+        AQDParticipatedProjectListResponseDto data =
+                aqdProjectService.getParticipatedProjects(userId);
+        return ResponseDto.ok(data);
     }
 
     @GetMapping("/projects/{projectId}")

--- a/src/main/java/com/monorama/iot_server/domain/AirQualityData.java
+++ b/src/main/java/com/monorama/iot_server/domain/AirQualityData.java
@@ -2,10 +2,12 @@ package com.monorama.iot_server.domain;
 
 import com.monorama.iot_server.domain.embedded.AirQualityDataItem;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "air_quality_data_tb")
 public class AirQualityData {
 

--- a/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDHistoryItemResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDHistoryItemResponseDto.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.monorama.iot_server.domain.AirQualityData;
 import com.monorama.iot_server.domain.embedded.AirQualityDataItem;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 public record AQDHistoryItemResponseDto(
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-        Date createdAt,
+        LocalDateTime createdAt,
 
         Double pm25Value,
         Double pm10Value,

--- a/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDHistoryItemResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDHistoryItemResponseDto.java
@@ -1,0 +1,38 @@
+package com.monorama.iot_server.dto.response.airquality;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.monorama.iot_server.domain.AirQualityData;
+import com.monorama.iot_server.domain.embedded.AirQualityDataItem;
+
+import java.util.Date;
+
+public record AQDHistoryItemResponseDto(
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        Date createdAt,
+
+        Double pm25Value,
+        Double pm10Value,
+        Double temperature,
+        Double humidity,
+        Double vocValue,
+        Double co2Value,
+        Double picoDeviceLatitude,
+        Double picoDeviceLongitude
+) {
+    public static AQDHistoryItemResponseDto fromEntity(AirQualityData entity) {
+        AirQualityDataItem item = entity.getAirQualityDataItem();
+
+        return new AQDHistoryItemResponseDto(
+                entity.getCreatedAt(),
+                item.getPm25Value(),
+                item.getPm10Value(),
+                item.getTemperature(),
+                item.getHumidity(),
+                item.getVocValue(),
+                item.getCo2Value(),
+                item.getPicoDeviceLatitude(),
+                item.getPicoDeviceLongitude()
+        );
+    }
+}

--- a/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDHistoryListResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDHistoryListResponseDto.java
@@ -1,0 +1,19 @@
+package com.monorama.iot_server.dto.response.airquality;
+
+import com.monorama.iot_server.domain.AirQualityData;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public record AQDHistoryListResponseDto(
+        List<AQDHistoryItemResponseDto> historyList,
+        boolean hasNext
+) {
+    public static AQDHistoryListResponseDto fromSlice(Slice<AirQualityData> slice) {
+        List<AQDHistoryItemResponseDto> list = slice.getContent().stream()
+                .map(AQDHistoryItemResponseDto::fromEntity)
+                .toList();
+
+        return new AQDHistoryListResponseDto(list, slice.hasNext());
+    }
+}

--- a/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDParticipatedProjectListResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDParticipatedProjectListResponseDto.java
@@ -1,0 +1,17 @@
+package com.monorama.iot_server.dto.response.airquality;
+
+import com.monorama.iot_server.domain.Project;
+
+import java.util.List;
+
+public record AQDParticipatedProjectListResponseDto(
+        List<AQDParticipatedProjectResponseDto> projects
+) {
+    public static AQDParticipatedProjectListResponseDto fromEntities(List<Project> projects) {
+        List<AQDParticipatedProjectResponseDto> list = projects.stream()
+                .map(AQDParticipatedProjectResponseDto::fromEntity)
+                .toList();
+
+        return new AQDParticipatedProjectListResponseDto(list);
+    }
+}

--- a/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDParticipatedProjectResponseDto.java
+++ b/src/main/java/com/monorama/iot_server/dto/response/airquality/AQDParticipatedProjectResponseDto.java
@@ -1,0 +1,15 @@
+package com.monorama.iot_server.dto.response.airquality;
+
+import com.monorama.iot_server.domain.Project;
+
+public record AQDParticipatedProjectResponseDto(
+        Long projectId,
+        String title
+) {
+    public static AQDParticipatedProjectResponseDto fromEntity(Project project) {
+        return new AQDParticipatedProjectResponseDto(
+                project.getId(),
+                project.getTitle()
+        );
+    }
+}

--- a/src/main/java/com/monorama/iot_server/repository/AQDRepository.java
+++ b/src/main/java/com/monorama/iot_server/repository/AQDRepository.java
@@ -1,7 +1,31 @@
 package com.monorama.iot_server.repository;
 
 import com.monorama.iot_server.domain.AirQualityData;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Date;
 
 public interface AQDRepository extends JpaRepository<AirQualityData, Long> {
+    @Query("""
+        SELECT a
+        FROM AirQualityData a
+            JOIN a.user u
+            JOIN UserProject up ON up.user = u
+        WHERE up.project.id = :projectId
+          AND u.id = :userId
+          AND a.createdAt >= :start
+          AND a.createdAt < :end
+        ORDER BY a.createdAt desc
+        """)
+    Slice<AirQualityData> findHistoryByProjectAndUserAndDate(
+            @Param("projectId") Long projectId,
+            @Param("userId") Long userId,
+            @Param("start") Date start,
+            @Param("end") Date end,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/monorama/iot_server/repository/UserProjectRepository.java
+++ b/src/main/java/com/monorama/iot_server/repository/UserProjectRepository.java
@@ -19,5 +19,11 @@ public interface UserProjectRepository extends JpaRepository<UserProject, Long> 
             "AND up.project.endDate >= :today")
     List<Project> findProgressProjectsByUserId(@Param("userId") Long userId, @Param("today") LocalDate today);
 
+    @Query("""
+        SELECT up.project
+        FROM UserProject up
+        WHERE up.user.id = :userId
+        """)
+    List<Project> findProjectsByUserId(@Param("userId") Long userId);
 }
 

--- a/src/main/java/com/monorama/iot_server/service/airquality/AQDHistoryService.java
+++ b/src/main/java/com/monorama/iot_server/service/airquality/AQDHistoryService.java
@@ -1,0 +1,52 @@
+package com.monorama.iot_server.service.airquality;
+
+import com.monorama.iot_server.domain.AirQualityData;
+import com.monorama.iot_server.dto.response.airquality.AQDHistoryListResponseDto;
+import com.monorama.iot_server.repository.AQDRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AQDHistoryService {
+
+    private final AQDRepository airQualityDataRepository;
+
+    public AQDHistoryListResponseDto getHistory(Long projectId, Long userId, LocalDate date, int page, int size) {
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+
+        ZonedDateTime startZdt = date.atStartOfDay(zoneId);
+        ZonedDateTime endZdt = date.plusDays(1).atStartOfDay(zoneId);
+
+        Date start = Date.from(startZdt.toInstant());
+        Date end = Date.from(endZdt.toInstant());
+
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt", "id")
+        );
+
+        Slice<AirQualityData> slice =
+                airQualityDataRepository.findHistoryByProjectAndUserAndDate(
+                        projectId,
+                        userId,
+                        start,
+                        end,
+                        pageable
+                );
+
+        return AQDHistoryListResponseDto.fromSlice(slice);
+    }
+}

--- a/src/main/java/com/monorama/iot_server/service/airquality/AQDProjectService.java
+++ b/src/main/java/com/monorama/iot_server/service/airquality/AQDProjectService.java
@@ -5,6 +5,7 @@ import com.monorama.iot_server.domain.User;
 import com.monorama.iot_server.domain.UserDataPermission;
 import com.monorama.iot_server.domain.UserProject;
 import com.monorama.iot_server.domain.type.TermsType;
+import com.monorama.iot_server.dto.response.airquality.AQDParticipatedProjectListResponseDto;
 import com.monorama.iot_server.dto.response.project.AirMetaDataItemResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectDetailResponseDto;
 import com.monorama.iot_server.dto.response.project.ProjectListResponseDto;
@@ -91,5 +92,11 @@ public class AQDProjectService {
         permission.getHealthDataFlag().updateBy(project.getHealthDataFlag());
         permission.getPersonalInfoFlag().updateBy(project.getPersonalInfoFlag());
 
+    }
+
+    public AQDParticipatedProjectListResponseDto getParticipatedProjects(Long userId) {
+        var projectList = userProjectRepo.findProjectsByUserId(userId);
+
+        return AQDParticipatedProjectListResponseDto.fromEntities(projectList);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolves: #80

## 📝 개요
- 사용자가 참가중인 프로젝트 목록 조회 및 사용자로부터 수집된 공기질 데이터를 조회하는 기능

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- 사용자가 참가중인 프로젝트 목록 조회
- 사용자로부터 수집된 공기질 데이터 조회


## 📌 체크리스트
- [ ] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [x] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [ ] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.

