### PR TITLE
:pencil2: Fix: 히스토리 기능 날짜 자료형 불일치 수정

### DIFF
--- a/src/main/java/com/monorama/iot_server/repository/AQDRepository.java
+++ b/src/main/java/com/monorama/iot_server/repository/AQDRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 public interface AQDRepository extends JpaRepository<AirQualityData, Long> {
     @Query("""
@@ -24,8 +24,8 @@ public interface AQDRepository extends JpaRepository<AirQualityData, Long> {
     Slice<AirQualityData> findHistoryByProjectAndUserAndDate(
             @Param("projectId") Long projectId,
             @Param("userId") Long userId,
-            @Param("start") Date start,
-            @Param("end") Date end,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
             Pageable pageable
     );
 }

--- a/src/main/java/com/monorama/iot_server/service/airquality/AQDHistoryService.java
+++ b/src/main/java/com/monorama/iot_server/service/airquality/AQDHistoryService.java
@@ -12,9 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -24,13 +22,9 @@ public class AQDHistoryService {
     private final AQDRepository airQualityDataRepository;
 
     public AQDHistoryListResponseDto getHistory(Long projectId, Long userId, LocalDate date, int page, int size) {
-        ZoneId zoneId = ZoneId.of("Asia/Seoul");
 
-        ZonedDateTime startZdt = date.atStartOfDay(zoneId);
-        ZonedDateTime endZdt = date.plusDays(1).atStartOfDay(zoneId);
-
-        Date start = Date.from(startZdt.toInstant());
-        Date end = Date.from(endZdt.toInstant());
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.plusDays(1).atStartOfDay();
 
         Pageable pageable = PageRequest.of(
                 page,


### PR DESCRIPTION
## 🔗 관련 이슈
없음

## 📝 개요
- 히스토리 기능 날짜 자료형 불일치 수정

## 🧩 PR 유형 (중복 선택 가능)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- air_quality_data_tb의 createdAt의 자료형과 AQDRepository 파일의 쿼리 파라미터 간의 자료형 불일치로 인해 에러 발생
- 히스토리 조회 쿼리에 Date 타입으로 들어가던 변수를 LocalDateTime으로 일치시킴


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [ ] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [ ] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.

